### PR TITLE
Move ContentGridSpringDataRestConfiguration import from test-fixtures to test

### DIFF
--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -38,6 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 import org.springframework.data.rest.webmvc.RestMediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -49,7 +51,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Transactional
 @SpringBootTest
 @AutoConfigureMockMvc(printOnlyOnFailure = false)
-class ThunxDemoApplicationTests {
+@Import(ContentGridSpringDataRestConfiguration.class)
+class InvoicingApplicationTests {
 
     static final String INVOICE_NUMBER_1 = "I-2022-0001";
     static final String INVOICE_NUMBER_2 = "I-2022-0002";

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 
 @SpringBootApplication
-@Import(ContentGridSpringDataRestConfiguration.class)
 public class InvoicingApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
This PR allows to reuse the text-fixtures in the thunx integration tests