### PR TITLE
Events for collections [ACC-536]

### DIFF
--- a/contentgrid-spring-integration-events/src/main/java/com/contentgrid/spring/integration/events/ContentGridPublisherEventListener.java
+++ b/contentgrid-spring-integration-events/src/main/java/com/contentgrid/spring/integration/events/ContentGridPublisherEventListener.java
@@ -3,7 +3,6 @@ package com.contentgrid.spring.integration.events;
 import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage;
 import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.ContentGridMessageTrigger;
 import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.DataEntity;
-import java.util.Map;
 import javax.persistence.EntityManagerFactory;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;

--- a/contentgrid-spring-integration-events/src/main/java/com/contentgrid/spring/integration/events/ContentGridPublisherEventListener.java
+++ b/contentgrid-spring-integration-events/src/main/java/com/contentgrid/spring/integration/events/ContentGridPublisherEventListener.java
@@ -1,9 +1,10 @@
 package com.contentgrid.spring.integration.events;
 
+import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage;
+import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.ContentGridMessageTrigger;
+import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.DataEntity;
 import java.util.Map;
-
 import javax.persistence.EntityManagerFactory;
-
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostCollectionUpdateEvent;
@@ -23,10 +24,6 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import org.springframework.util.StringUtils;
-
-import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage;
-import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.ContentGridMessageTrigger;
-import com.contentgrid.spring.integration.events.ContentGridEventPublisher.ContentGridMessage.DataEntity;
 
 public class ContentGridPublisherEventListener implements PostInsertEventListener,
         PostUpdateEventListener, PostDeleteEventListener, PostCollectionUpdateEventListener,
@@ -55,7 +52,6 @@ public class ContentGridPublisherEventListener implements PostInsertEventListene
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     public boolean requiresPostCommitHanding(EntityPersister persister) {
         return this.requiresPostCommitHandling(persister);
     }
@@ -111,6 +107,5 @@ public class ContentGridPublisherEventListener implements PostInsertEventListene
                 .filter(StringUtils::hasText)
                 .orElseGet(() -> entity.getClass().getSimpleName().toLowerCase());
     }
-
 
 }

--- a/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
+++ b/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
@@ -1,11 +1,16 @@
 package com.contentgrid.userapps.holmes.dcm.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.lang.String;
 import java.util.UUID;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -22,4 +27,9 @@ public class Case {
 	private String name;
 
 	private String description;
+
+	@ManyToMany
+	@JoinTable(name = "case__suspects", joinColumns = @JoinColumn(name = "case_id"), inverseJoinColumns = @JoinColumn(name = "person_id"))
+	@JsonIgnore
+	private List<Person> suspects;
 }

--- a/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
+++ b/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
@@ -1,6 +1,7 @@
 package com.contentgrid.userapps.holmes.dcm.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.lang.String;
 import java.util.UUID;
 import java.util.List;
@@ -11,9 +12,13 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @Entity
 @NoArgsConstructor
@@ -32,4 +37,21 @@ public class Case {
 	@JoinTable(name = "case__suspects", joinColumns = @JoinColumn(name = "case_id"), inverseJoinColumns = @JoinColumn(name = "person_id"))
 	@JsonIgnore
 	private List<Person> suspects;
+
+	@ManyToOne
+	@JoinColumn(name = "lead_detective")
+	@JsonProperty("lead_detective")
+	@RestResource(rel = "lead_detective", path = "lead-detective")
+	private Person leadDetective;
+
+	@OneToMany
+	@JoinColumn(name = "_case_id__has_evidence")
+	@JsonIgnore
+	@RestResource(rel = "has_evidence", path = "has-evidence")
+	private List<Evidence> hasEvidence;
+
+	@OneToOne
+	@JoinColumn(name = "scenario")
+	private Evidence scenario;
+
 }

--- a/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
+++ b/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Case.java
@@ -2,9 +2,8 @@ package com.contentgrid.userapps.holmes.dcm.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.lang.String;
-import java.util.UUID;
 import java.util.List;
+import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;

--- a/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Evidence.java
+++ b/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/model/Evidence.java
@@ -1,0 +1,27 @@
+package com.contentgrid.userapps.holmes.dcm.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.lang.String;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@Setter
+public class Evidence {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    private UUID id;
+
+    private String name;
+
+    private String description;
+}

--- a/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/repository/EvidenceRepository.java
+++ b/integration-tests/integration-tests-spring/src/main/java/com/contentgrid/userapps/holmes/dcm/repository/EvidenceRepository.java
@@ -1,0 +1,11 @@
+package com.contentgrid.userapps.holmes.dcm.repository;
+
+import com.contentgrid.userapps.holmes.dcm.model.Evidence;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource
+interface EvidenceRepository extends JpaRepository<Evidence, UUID>, QuerydslPredicateExecutor<Evidence> {
+}

--- a/integration-tests/integration-tests-spring/src/main/resources/application.yml
+++ b/integration-tests/integration-tests-spring/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
   datasource:
     url: jdbc:tc:postgresql:14:///
   jpa:
+    show-sql: true
     hibernate:
       ddl-auto: create-drop
     properties:

--- a/integration-tests/integration-tests-spring/src/test/java/com/contentgrid/userapps/holmes/dcm/repository/DcmApiRepositoryIntegrationEventsTests.java
+++ b/integration-tests/integration-tests-spring/src/test/java/com/contentgrid/userapps/holmes/dcm/repository/DcmApiRepositoryIntegrationEventsTests.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.List;
 
 import javax.persistence.EntityManagerFactory;
 
@@ -31,6 +32,7 @@ import com.contentgrid.spring.integration.events.ContentGridEventPublisher;
 import com.contentgrid.spring.integration.events.ContentGridMessageHandler;
 import com.contentgrid.spring.integration.events.ContentGridPublisherEventListener;
 import com.contentgrid.userapps.holmes.dcm.model.Case;
+import com.contentgrid.userapps.holmes.dcm.model.Person;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -101,6 +103,9 @@ class DcmApiRepositoryIntegrationEventsTests {
     CaseRepository repository;
 
     @Autowired
+    PersonRepository personRepository;
+
+    @Autowired
     ContentGridPublisherEventListener listener;
 
     @Autowired
@@ -119,6 +124,7 @@ class DcmApiRepositoryIntegrationEventsTests {
         verify(listener, times(1)).onPostInsert(any());
         verify(listener, times(0)).onPostUpdate(any());
         verify(listener, times(0)).onPostDelete(any());
+        verify(listener, times(0)).onPostUpdateCollection(any());
 
         verify(contentGridMessageHandler.get().get(), times(1)).handleMessage(any());
     }
@@ -130,6 +136,7 @@ class DcmApiRepositoryIntegrationEventsTests {
         verify(listener, times(2)).onPostInsert(any());
         verify(listener, times(0)).onPostUpdate(any());
         verify(listener, times(0)).onPostDelete(any());
+        verify(listener, times(0)).onPostUpdateCollection(any());
 
         verify(contentGridMessageHandler.get().get(), times(2)).handleMessage(any());
     }
@@ -147,6 +154,7 @@ class DcmApiRepositoryIntegrationEventsTests {
         verify(listener, times(1)).onPostInsert(any());
         verify(listener, times(1)).onPostUpdate(any());
         verify(listener, times(0)).onPostDelete(any());
+        verify(listener, times(0)).onPostUpdateCollection(any());
 
         verify(contentGridMessageHandler.get().get(), times(2)).handleMessage(any());
     }
@@ -163,6 +171,7 @@ class DcmApiRepositoryIntegrationEventsTests {
         verify(listener, times(1)).onPostInsert(any());
         verify(listener, times(2)).onPostUpdate(any());
         verify(listener, times(0)).onPostDelete(any());
+        verify(listener, times(0)).onPostUpdateCollection(any());
 
         verify(contentGridMessageHandler.get().get(), times(3)).handleMessage(any());
     }
@@ -179,6 +188,24 @@ class DcmApiRepositoryIntegrationEventsTests {
         verify(listener, times(1)).onPostInsert(any());
         verify(listener, times(1)).onPostUpdate(any());
         verify(listener, times(1)).onPostDelete(any());
+        verify(listener, times(0)).onPostUpdateCollection(any());
+
+        verify(contentGridMessageHandler.get().get(), times(3)).handleMessage(any());
+    }
+
+    @Test
+    void whenPersonIsAddedToCaseSuspects_postUpdateShouldBeCalledOnce_ok() {
+        Case _case = repository.save(new Case());
+        Person person = personRepository.save(new Person());
+
+        _case.setSuspects(List.of(person));
+        repository.save(_case);
+        personRepository.save(person);
+
+        verify(listener, times(2)).onPostInsert(any());
+        verify(listener, times(0)).onPostUpdate(any());
+        verify(listener, times(0)).onPostDelete(any());
+        verify(listener, times(1)).onPostUpdateCollection(any());
 
         verify(contentGridMessageHandler.get().get(), times(3)).handleMessage(any());
     }


### PR DESCRIPTION
Unfortunately, these events say very little and do not contain a
meaningful before/after or diff. There appears to be no way for us to
get this data without reading out the entire join table and the one from
the snapshot, and diffing on that. This is a very expensive operation in
case of a large table.