### PR TITLE
Fall back to spring-data-rest implementation for non-implemented cases in DelegatingRepositoryPropertyReferenceController

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -1,8 +1,11 @@
 package com.contentgrid.spring.boot.autoconfigure.data.web;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.rest.webmvc.ContentGridRestProperties;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 
@@ -10,5 +13,10 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
 @ConditionalOnClass({ContentGridSpringDataRestConfiguration.class, RepositoryRestMvcConfiguration.class})
 @Import(ContentGridSpringDataRestConfiguration.class)
 public class ContentGridSpringDataRestAutoConfiguration {
+    @Bean
+    @ConfigurationProperties("contentgrid.rest")
+    ContentGridRestProperties contentGridRestProperties() {
+        return new ContentGridRestProperties();
+    }
 
 }

--- a/contentgrid-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/contentgrid-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 com.contentgrid.spring.boot.autoconfigure.s3.S3RegionAutoConfiguration,\
 com.contentgrid.spring.boot.autoconfigure.actuator.ActuatorAutoConfiguration,\
-com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration
+com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration,\
+com.contentgrid.spring.boot.autoconfigure.data.web.ContentGridSpringDataRestAutoConfiguration

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridRestProperties.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridRestProperties.java
@@ -1,0 +1,8 @@
+package org.springframework.data.rest.webmvc;
+
+import lombok.Data;
+
+@Data
+public class ContentGridRestProperties {
+    boolean fallbackToDefaultRelationController = false;
+}

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
@@ -3,7 +3,6 @@ package org.springframework.data.rest.webmvc;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.content.rest.config.ContentRestConfigurer;
-import org.springframework.content.rest.config.RestConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,8 +27,8 @@ public class ContentGridSpringDataRestConfiguration {
                             applicationContext.getBean(RepositoryResourceMappings.class),
                             applicationContext.getBean(RepositoryEntityLinks.class),
                             applicationContext.getBean(SelfLinkProvider.class),
-                            applicationContext.getBeanProvider(QuerydslBindingsFactory.class)
-                    );
+                            applicationContext.getBeanProvider(QuerydslBindingsFactory.class),
+                            applicationContext.getBeanProvider(ContentGridRestProperties.class).getIfAvailable(ContentGridRestProperties::new));
                 }
 
                 return bean;


### PR DESCRIPTION
This is necessary to bridge the gap while bi-directional relations are not yet fully supported.
It default to disabled, because it also has security implications when used in conjunction with thunx
