### PR TITLE
Use old-fashioned Random

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileController.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileController.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Objects;
-import java.util.random.RandomGenerator;
+import java.util.Random;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -43,7 +43,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @RequiredArgsConstructor
 @BasePathAwareController
 public class HalFormsProfileController implements InitializingBean {
-    private static final RandomGenerator RANDOM = RandomGenerator.getDefault();
 
     private final RepositoryRestConfiguration configuration;
     private final EntityLinks entityLinks;
@@ -83,8 +82,9 @@ public class HalFormsProfileController implements InitializingBean {
                 .withName(IanaLinkRelations.COLLECTION_VALUE);
 
         var placeholder = new StringBuilder("---");
+        var random = new Random();
         while(placeholder.length() < 10) {
-            placeholder.append(RANDOM.nextInt('a', 'z'));
+            placeholder.append(random.nextInt('a', 'z'));
         }
         placeholder.append("---");
         var itemLinkTemplate = entityLinks.linkToItemResource(information.getDomainType(), placeholder.toString())


### PR DESCRIPTION
1. We shouldn't be using non-threadsafe RandomGenerators across multiple threads
2. Using the same random across multiple threads can result in lock contention
3. RandomGenerator.getDefault() references a random implementation that is currently not available in all JREs
