### PR TITLE
Add custom CurieProvider

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -1,9 +1,11 @@
 package com.contentgrid.spring.boot.autoconfigure.data.web;
 
 import com.contentgrid.spring.data.rest.affordances.ContentGridSpringDataRestAffordancesConfiguration;
-import com.contentgrid.spring.data.rest.hal.ContentGridSpringDataRestHalConfiguration;
+import com.contentgrid.spring.data.rest.hal.ContentGridCurieConfiguration;
+import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
 import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,8 +21,7 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
 @Import({
         ContentGridSpringDataRestConfiguration.class,
         ContentGridSpringDataRestProfileConfiguration.class,
-        ContentGridSpringDataRestAffordancesConfiguration.class,
-        ContentGridSpringDataRestHalConfiguration.class
+        ContentGridSpringDataRestAffordancesConfiguration.class
 })
 @AutoConfigureAfter(HypermediaAutoConfiguration.class)
 public class ContentGridSpringDataRestAutoConfiguration {
@@ -29,6 +30,12 @@ public class ContentGridSpringDataRestAutoConfiguration {
     @ConfigurationProperties("contentgrid.rest")
     ContentGridRestProperties contentGridRestProperties() {
         return new ContentGridRestProperties();
+    }
+
+    @ConditionalOnBean(CurieProviderCustomizer.class)
+    @Import(ContentGridCurieConfiguration.class)
+    static class CurieAutoConfiguration {
+
     }
 
 }

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.contentgrid.spring.boot.autoconfigure.data.web;
 
 import com.contentgrid.spring.data.rest.affordances.ContentGridSpringDataRestAffordancesConfiguration;
+import com.contentgrid.spring.data.rest.hal.ContentGridSpringDataRestHalConfiguration;
 import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -15,8 +16,12 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
 
 @Configuration
 @ConditionalOnClass({ContentGridSpringDataRestConfiguration.class, RepositoryRestMvcConfiguration.class})
-@Import({ContentGridSpringDataRestConfiguration.class, ContentGridSpringDataRestProfileConfiguration.class,
-        ContentGridSpringDataRestAffordancesConfiguration.class})
+@Import({
+        ContentGridSpringDataRestConfiguration.class,
+        ContentGridSpringDataRestProfileConfiguration.class,
+        ContentGridSpringDataRestAffordancesConfiguration.class,
+        ContentGridSpringDataRestHalConfiguration.class
+})
 @AutoConfigureAfter(HypermediaAutoConfiguration.class)
 public class ContentGridSpringDataRestAutoConfiguration {
 

--- a/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
+++ b/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
@@ -2,14 +2,19 @@ package com.contentgrid.spring.boot.autoconfigure.data.web;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
+import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 import org.springframework.data.rest.webmvc.DelegatingRepositoryPropertyReferenceController;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
 import org.springframework.hateoas.mediatype.hal.HalConfiguration;
 import org.springframework.hateoas.mediatype.hal.forms.HalFormsConfiguration;
 
@@ -26,6 +31,7 @@ class ContentGridSpringDataRestAutoConfigurationTest {
         contextRunner.run(context -> {
             assertThat(context).hasSingleBean(DelegatingRepositoryPropertyReferenceController.class);
             assertThat(context).hasBean("repositoryPropertyReferenceController");
+            assertThat(context).doesNotHaveBean(CurieProvider.class);
             assertThat(context).hasNotFailed();
         });
     }
@@ -61,5 +67,24 @@ class ContentGridSpringDataRestAutoConfigurationTest {
                     assertThat(context).doesNotHaveBean("repositoryPropertyReferenceController");
                     assertThat(context).hasNotFailed();
                 });
+    }
+
+    @Test
+    void when_curieProviderCustomizer_isPresent() {
+        contextRunner
+                .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasSingleBean(CurieProvider.class);
+                    assertThat(context).hasNotFailed();
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    private static class CurieCustomizerConfiguration {
+        @Bean
+        CurieProviderCustomizer myCurieProviderCustomizer() {
+            return CurieProviderCustomizer.register("test", "https://test.invalid/{rel}");
+        }
+
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfiguration.java
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.mediatype.hal.CurieProvider;
 
 @Configuration(proxyBeanMethods = false)
-public class ContentGridSpringDataRestHalConfiguration {
+public class ContentGridCurieConfiguration {
 
     @Bean
     CurieProvider contentGridCurieProvider(ObjectProvider<CurieProviderCustomizer> customizers) {

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProvider.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProvider.java
@@ -1,0 +1,65 @@
+package com.contentgrid.spring.data.rest.hal;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.Links;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+
+@RequiredArgsConstructor
+class ContentGridCurieProvider implements CurieProvider, CurieProviderBuilder {
+
+    private final Map<String, UriTemplate> curies;
+
+    public ContentGridCurieProvider() {
+        this(Map.of());
+    }
+
+    @Override
+    public HalLinkRelation getNamespacedRelFrom(Link link) {
+        return getNamespacedRelFor(link.getRel());
+    }
+
+    @Override
+    public HalLinkRelation getNamespacedRelFor(LinkRelation rel) {
+        return HalLinkRelation.of(rel);
+    }
+
+    @Override
+    public Collection<?> getCurieInformation(Links links) {
+        return curies.entrySet().stream()
+                .map(it -> createCurieLink(it.getKey(), it.getValue()))
+                .toList();
+    }
+
+    private Link createCurieLink(String name, UriTemplate template) {
+        return Link.of(
+                template,
+                HalLinkRelation.CURIES
+        ).withName(name);
+    }
+
+    @Override
+    public CurieProviderBuilder withCurie(String prefix, UriTemplate template) {
+        if(curies.containsKey(prefix)) {
+            throw new IllegalArgumentException("Curie prefix '%s' is already registered with template '%s' and can not be re-registered with template '%s'.".formatted(
+                    prefix,
+                    curies.get(prefix),
+                    template
+            ));
+        }
+        var curies = new HashMap<>(this.curies);
+        curies.put(prefix, template);
+        return new ContentGridCurieProvider(curies);
+    }
+
+    @Override
+    public CurieProvider build() {
+        return this;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfiguration.java
@@ -1,6 +1,5 @@
 package com.contentgrid.spring.data.rest.hal;
 
-import java.util.Map;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfiguration.java
@@ -1,0 +1,23 @@
+package com.contentgrid.spring.data.rest.hal;
+
+import java.util.Map;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+
+@Configuration(proxyBeanMethods = false)
+public class ContentGridSpringDataRestHalConfiguration {
+
+    @Bean
+    CurieProvider contentGridCurieProvider(ObjectProvider<CurieProviderCustomizer> customizers) {
+        CurieProviderBuilder curieProvider = new ContentGridCurieProvider();
+
+        for (CurieProviderCustomizer customizer : customizers) {
+            curieProvider = customizer.customize(curieProvider);
+        }
+
+        return curieProvider.build();
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderBuilder.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderBuilder.java
@@ -1,0 +1,9 @@
+package com.contentgrid.spring.data.rest.hal;
+
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+
+public interface CurieProviderBuilder {
+    CurieProviderBuilder withCurie(String prefix, UriTemplate template);
+    CurieProvider build();
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderBuilder.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderBuilder.java
@@ -3,7 +3,22 @@ package com.contentgrid.spring.data.rest.hal;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.mediatype.hal.CurieProvider;
 
+/**
+ * Fluent builder for {@link CurieProvider}
+ */
 public interface CurieProviderBuilder {
+
+    /**
+     * Adds a mapping from CURIE prefix to a {@link UriTemplate} for resolving the CURIE against
+     * @param prefix CURIE prefix
+     * @param template Template to use to resolve the CURIE
+     * @return Copy with new curie mapping applied
+     */
     CurieProviderBuilder withCurie(String prefix, UriTemplate template);
+
+    /**
+     * Builds a {@link CurieProvider} with the mappings specified in the builder
+     * @return An immutable {@link CurieProvider} instance
+     */
     CurieProvider build();
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
@@ -1,5 +1,15 @@
 package com.contentgrid.spring.data.rest.hal;
 
+import org.springframework.hateoas.UriTemplate;
+
 public interface CurieProviderCustomizer {
     CurieProviderBuilder customize(CurieProviderBuilder builder);
+
+    static CurieProviderCustomizer register(String curiePrefix, UriTemplate template) {
+        return builder -> builder.withCurie(curiePrefix, template);
+    }
+
+    static CurieProviderCustomizer register(String curiePrefix, String template) {
+        return register(curiePrefix, UriTemplate.of(template));
+    }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
@@ -2,13 +2,45 @@ package com.contentgrid.spring.data.rest.hal;
 
 import org.springframework.hateoas.UriTemplate;
 
+/**
+ * Customizer interface for {@link CurieProviderBuilder}.
+ * <p>
+ * By implementing this interface and exposing them as beans, they will automatically be applied to the default {@link org.springframework.hateoas.mediatype.hal.CurieProvider}
+ */
+@FunctionalInterface
 public interface CurieProviderCustomizer {
+
+    /**
+     * Customize the {@link CurieProviderBuilder}
+     * @param builder current builder
+     * @return builder with the desired customizations applied
+     */
     CurieProviderBuilder customize(CurieProviderBuilder builder);
 
+    /**
+     * Register a mapping between CURIE prefix and a URI template
+     *
+     * @param curiePrefix The CURIE prefix
+     * @param template The URI template to use
+     * @return customizer that registers a CURIE prefix mapping
+     *
+     * @see CurieProviderBuilder#withCurie(String, UriTemplate) for the builder method
+     * @see #register(String, String) for a shortcut that does not require a {@link UriTemplate} instance
+     */
     static CurieProviderCustomizer register(String curiePrefix, UriTemplate template) {
         return builder -> builder.withCurie(curiePrefix, template);
     }
 
+    /**
+     * Register a mapping between CURIE prefix and a URI template
+     *
+     * @param curiePrefix The CURIE prefix
+     * @param template The URI template to use
+     * @return customizer that registers a CURIE prefix mapping
+     *
+     * @see CurieProviderBuilder#withCurie(String, UriTemplate) for the builder method
+     * @see #register(String, UriTemplate) for passing a {@link UriTemplate} directly
+     */
     static CurieProviderCustomizer register(String curiePrefix, String template) {
         return register(curiePrefix, UriTemplate.of(template));
     }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/CurieProviderCustomizer.java
@@ -1,0 +1,5 @@
+package com.contentgrid.spring.data.rest.hal;
+
+public interface CurieProviderCustomizer {
+    CurieProviderBuilder customize(CurieProviderBuilder builder);
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -95,7 +95,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
                             _embedded: {
-                                customers: [
+                                "d:customers": [
                                     {
                                         _links: {
                                             self: {
@@ -137,7 +137,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                 // No top-level _templates are present
                 .andExpect(MockMvcResultMatchers.jsonPath("$.keys()", Matchers.not(Matchers.contains("_templates"))))
                 // The templates of the embedded object only contain a default and a delete template
-                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.customers[0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.['d:customers'][0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
         ;
     }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfigurationTest.java
@@ -1,10 +1,8 @@
 package com.contentgrid.spring.data.rest.hal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-import com.contentgrid.spring.data.rest.hal.ContentGridSpringDataRestHalConfigurationTest.CurieProviderCustomizers;
-import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.data.rest.hal.ContentGridCurieConfigurationTest.CurieProviderCustomizers;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -21,11 +19,11 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ContextConfiguration(classes = {
-        ContentGridSpringDataRestHalConfiguration.class,
+        ContentGridCurieConfiguration.class,
         CurieProviderCustomizers.class
 })
 @AutoConfigureMockMvc(printOnlyOnFailure = false)
-class ContentGridSpringDataRestHalConfigurationTest {
+class ContentGridCurieConfigurationTest {
 
     @TestConfiguration(proxyBeanMethods = false)
     static class CurieProviderCustomizers {

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProviderTest.java
@@ -1,0 +1,21 @@
+package com.contentgrid.spring.data.rest.hal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.hateoas.UriTemplate;
+
+class ContentGridCurieProviderTest {
+    @Test
+    void duplicateCurie_rejected() {
+        var curieProvider = new ContentGridCurieProvider()
+                .withCurie("test", UriTemplate.of("http://example.invalid/{rel}"));
+
+        assertThatThrownBy(() -> {
+            curieProvider.withCurie("test", UriTemplate.of("http://test.invalid/{rel}"));
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Curie prefix 'test' is already registered");
+
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProviderTest.java
@@ -1,21 +1,60 @@
 package com.contentgrid.spring.data.rest.hal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.hateoas.LinkRelation;
 import org.springframework.hateoas.UriTemplate;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
 
 class ContentGridCurieProviderTest {
+
+    public static final CurieProviderBuilder CURIE_PROVIDER_BUILDER = new ContentGridCurieProvider()
+            .withCurie("test", UriTemplate.of("http://example.invalid/{rel}"));
+
     @Test
-    void duplicateCurie_rejected() {
-        var curieProvider = new ContentGridCurieProvider()
-                .withCurie("test", UriTemplate.of("http://example.invalid/{rel}"));
-
+    void withCurie_duplicate() {
         assertThatThrownBy(() -> {
-            curieProvider.withCurie("test", UriTemplate.of("http://test.invalid/{rel}"));
+            CURIE_PROVIDER_BUILDER.withCurie("test", UriTemplate.of("http://test.invalid/{rel}"));
         }).isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Curie prefix 'test' is already registered");
+                .hasMessageContaining("CURIE prefix 'test' is already registered");
+    }
 
+    @Test
+    void withCurie_ianaScheme() {
+        assertThatThrownBy(() -> {
+            CURIE_PROVIDER_BUILDER.withCurie("http", UriTemplate.of("http://test.invalid/{rel}"));
+        }).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("CURIE prefix 'http' can not be an IANA-registered URI scheme");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "self",
+            "test:abc",
+            "http://example.com/rels/xyz"
+    })
+    void getNamespacedRelFor_valid(String rel) {
+        assertThat(CURIE_PROVIDER_BUILDER.build().getNamespacedRelFor(LinkRelation.of(rel)))
+                .extracting(HalLinkRelation::value)
+                .isEqualTo(rel);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "some-unregistered-thing",
+            "nocurie:abc",
+            "nocurie://xyz/def"
+    })
+    void getNamespacedRelFor_invalid(String rel) {
+        var curieProvider = CURIE_PROVIDER_BUILDER.build();
+
+        assertThatThrownBy(() -> curieProvider.getNamespacedRelFor(LinkRelation.of(rel)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Relation '%s'".formatted(rel));
     }
 
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfigurationTest.java
@@ -1,0 +1,54 @@
+package com.contentgrid.spring.data.rest.hal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.contentgrid.spring.data.rest.hal.ContentGridSpringDataRestHalConfigurationTest.CurieProviderCustomizers;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.Links;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class,
+        CurieProviderCustomizers.class
+})
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+class ContentGridSpringDataRestHalConfigurationTest {
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class CurieProviderCustomizers {
+        @Bean
+        CurieProviderCustomizer curieProviderTestCustomizer() {
+            return builder -> builder.withCurie("test", UriTemplate.of("https://example.com/rels/{x}"));
+        }
+
+        @Bean
+        CurieProviderCustomizer curieProviderExtCustomizer() {
+            return builder -> builder.withCurie("ext", UriTemplate.of("https://ext.invalid/{rel}"));
+        }
+    }
+
+    @Test
+    void customizersApplied(ApplicationContext context) {
+        var curies = context.getBean(CurieProvider.class).getCurieInformation(Links.NONE);
+
+        assertThat(curies).asInstanceOf(InstanceOfAssertFactories.list(Link.class)).containsExactlyInAnyOrder(
+                Link.of("https://example.com/rels/{x}", HalLinkRelation.CURIES).withName("test"),
+                Link.of("https://ext.invalid/{rel}", HalLinkRelation.CURIES).withName("ext")
+        );
+    }
+
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridSpringDataRestHalConfigurationTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
 @ContextConfiguration(classes = {
-        InvoicingApplication.class,
+        ContentGridSpringDataRestHalConfiguration.class,
         CurieProviderCustomizers.class
 })
 @AutoConfigureMockMvc(printOnlyOnFailure = false)

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -143,7 +143,7 @@ class InvoicingApplicationTests {
                 mockMvc.perform(get("/invoices")
                                 .contentType("application/json"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.invoices.length()").value(2));
+                        .andExpect(jsonPath("$._embedded.['d:invoices'].length()").value(2));
             }
         }
 
@@ -188,7 +188,7 @@ class InvoicingApplicationTests {
                                         {
                                             "customer": "/customers/%s",
                                             "_links": {
-                                                "promos" : [
+                                                "d:promos" : [
                                                     { "href": "/promotions/XMAS-2022" },
                                                     { "href": "/promotions/FREE-SHIP" }
                                                 ]

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
@@ -1,7 +1,9 @@
 package com.contentgrid.spring.test.fixture.invoicing;
 
+import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 
@@ -10,6 +12,11 @@ public class InvoicingApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(InvoicingApplication.class, args);
+    }
+
+    @Bean
+    CurieProviderCustomizer datamodelCurieProviderCustomizer() {
+        return CurieProviderCustomizer.register("d", "https://contentgrid.com/rels/datamodel/{rel}");
     }
 
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -44,15 +44,17 @@ public class Customer {
     @AttributeOverride(name = "length", column = @Column(name = "content__length"))
     @AttributeOverride(name = "mimetype", column = @Column(name = "content__mimetype"))
     @AttributeOverride(name = "filename", column = @Column(name = "content__filename"))
-    @RestResource(linkRel = "content", path = "content")
+    @RestResource(linkRel = "d:content", path = "content")
     @CollectionFilterParam
     private Content content;
 
     @OneToMany(mappedBy = "customer")
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:orders")
     private Set<Order> orders = new HashSet<>();
 
     @OneToMany(mappedBy="counterparty")
     @CollectionFilterParam
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:invoices")
     private Set<Invoice> invoices = new HashSet<>();
 
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -23,6 +23,7 @@ import org.springframework.content.commons.annotations.ContentId;
 import org.springframework.content.commons.annotations.ContentLength;
 import org.springframework.content.commons.annotations.MimeType;
 import org.springframework.content.commons.annotations.OriginalFileName;
+import org.springframework.content.rest.RestResource;
 
 @Entity
 @Getter
@@ -45,6 +46,7 @@ public class Invoice {
 
     @ContentId
     @JsonIgnore
+    @RestResource(linkRel = "d:content")
     private String contentId;
 
     @ContentLength
@@ -64,6 +66,7 @@ public class Invoice {
 
     @ContentId
     @JsonIgnore
+    @RestResource(linkRel = "d:attachment")
     private String attachmentId;
 
     @ContentLength
@@ -80,10 +83,12 @@ public class Invoice {
 
     @ManyToOne(optional = false)
     @JoinColumn(name = "counterparty", nullable = false)
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:counterparty")
     private Customer counterparty;
 
     @OneToMany(mappedBy = "invoice")
     @CollectionFilterParam
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:orders")
     private Set<Order> orders = new HashSet<>();
 
     public Invoice(String number, boolean draft, boolean paid, Customer counterparty, Set<Order> orders) {

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @Entity
 @Getter
@@ -34,19 +35,23 @@ public class Order {
     @ManyToOne
     @JoinColumn(name = "customer")
     @CollectionFilterParam
+    @RestResource(rel = "d:customer")
     private Customer customer;
 
     @ManyToOne
     @JoinColumn(name = "invoice", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"invoice\") references \"invoice\" ON DELETE set NULL"))
     @CollectionFilterParam
+    @RestResource(rel = "d:invoice")
     private Invoice invoice;
 
     @ManyToMany
+    @RestResource(rel = "d:promos")
     private Set<PromotionCampaign> promos = new HashSet<>();
 
     @OneToOne
     @JsonProperty("shipping_address")
     @CollectionFilterParam("shipping_address")
+    @RestResource(rel = "d:shipping-address")
     private ShippingAddress shippingAddress;
 
     public Order(Customer customer) {

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @Entity
 @Getter
@@ -30,11 +31,13 @@ public class PromotionCampaign {
 
     @Column(updatable = false, nullable = false)
     @CollectionFilterParam(value = "promo_code")
+    @RestResource(rel = "d:promo-code")
     private String promoCode;
 
     String description;
 
     @ManyToMany(mappedBy = "promos")
+    @RestResource(rel = "d:orders")
     private Set<Order> orders = new HashSet<>();
 
     public PromotionCampaign(String promoCode, String description) {

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/ShippingAddress.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/ShippingAddress.java
@@ -12,6 +12,7 @@ import javax.persistence.OneToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.rest.core.annotation.RestResource;
 
 @Entity
 @Getter
@@ -30,6 +31,7 @@ public class ShippingAddress {
     private String city;
 
     @OneToOne(mappedBy = "shippingAddress")
+    @RestResource(rel = "d:order")
     private Order order;
 
     public ShippingAddress(String street, String zip, String city) {

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/CustomerRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/CustomerRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(itemResourceRel = "d:customer", collectionResourceRel = "d:customers")
 public interface CustomerRepository extends JpaRepository<Customer, UUID>, QuerydslPredicateExecutor<Customer> {
 
     Optional<Customer> findByVat(String vat);

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/InvoiceRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/InvoiceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(itemResourceRel = "d:invoice", collectionResourceRel = "d:invoices")
 public interface InvoiceRepository extends JpaRepository<Invoice, UUID>, QuerydslPredicateExecutor<Invoice> {
 
     Optional<Invoice> findByNumber(String number);

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/OrderRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/OrderRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(itemResourceRel = "d:order", collectionResourceRel = "d:orders")
 public interface OrderRepository extends JpaRepository<Order, UUID>, QuerydslPredicateExecutor<Order> {
 
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/PromotionCampaignRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/PromotionCampaignRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource(path = "promotions")
+@RepositoryRestResource(path = "promotions", collectionResourceRel = "d:promotions", itemResourceRel = "d:promotion")
 public interface PromotionCampaignRepository extends JpaRepository<PromotionCampaign, UUID>,
         QuerydslPredicateExecutor<PromotionCampaign> {
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/ShippingAddressRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/ShippingAddressRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource(path = "shipping-addresses")
+@RepositoryRestResource(path = "shipping-addresses", itemResourceRel = "d:shipping-address", collectionResourceRel = "d:shipping-addresses")
 public interface ShippingAddressRepository extends JpaRepository<ShippingAddress, UUID>, QuerydslPredicateExecutor<ShippingAddress> {
 
 }

--- a/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ContentGridHalAssemblerTest.java
+++ b/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ContentGridHalAssemblerTest.java
@@ -29,8 +29,8 @@ class ContentGridHalAssemblerTest {
         var model = assembler.toModel(invoice);
 
         assertThat(model.getLink(IanaLinkRelations.SELF)).isPresent();
-        assertThat(model.getLink("content")).isPresent();
-        assertThat(model.getLink("attachment")).isPresent();
+        assertThat(model.getLink("d:content")).isPresent();
+        assertThat(model.getLink("d:attachment")).isPresent();
     }
 
 }


### PR DESCRIPTION
- Add custom curie provider that does not automatically curie links
- Add utility-methods to CurieProviderCustomizer to register a curie
- Make CurieProvider validate registered curie prefixes and link relations
- Add javadoc to CurieProvider{Builder,Customizer} interfaces
