### PR TITLE
Add support for generic link relations based on datamodel

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/build.gradle
+++ b/contentgrid-spring-boot-autoconfigure/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.data:spring-data-rest-webmvc'
     testImplementation 'com.github.paulcwarren:spring-content-s3-boot-starter'
+    testImplementation 'com.github.paulcwarren:spring-content-rest-boot-starter'
 
     testCompileOnly 'org.projectlombok:lombok'
 

--- a/contentgrid-spring-boot-autoconfigure/build.gradle
+++ b/contentgrid-spring-boot-autoconfigure/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compileOnly 'org.springframework.integration:spring-integration-core'
     compileOnly "com.github.paulcwarren:spring-content-autoconfigure"
     compileOnly "com.github.paulcwarren:spring-content-s3"
+    compileOnly "com.github.paulcwarren:spring-content-rest"
     compileOnly 'org.springframework.data:spring-data-rest-webmvc'
     compileOnly 'jakarta.persistence:jakarta.persistence-api'
 

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -9,7 +9,6 @@ import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileC
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.content.rest.config.RestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +25,15 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
         ContentGridSpringDataRestProfileConfiguration.class,
         ContentGridSpringDataRestAffordancesConfiguration.class,
 })
-@AutoConfigureAfter(HypermediaAutoConfiguration.class)
+@AutoConfigureAfter(
+        name = {
+                // Specifically ContentGridSpringContentRestLinksAutoConfiguration must run after spring-content
+                // is initialized so @ConditionalOnBean works correctly. Putting the annotation directly on that class
+                // does not work, because it is not an autoconfiguration, but is initialized directly when this parent class
+                // is initialized.
+                "internal.org.springframework.content.rest.boot.autoconfigure.ContentRestAutoConfiguration"
+        }
+)
 public class ContentGridSpringDataRestAutoConfiguration {
 
     @Bean
@@ -35,7 +42,6 @@ public class ContentGridSpringDataRestAutoConfiguration {
         return new ContentGridRestProperties();
     }
 
-    @Configuration(proxyBeanMethods = false)
     @ConditionalOnBean(CurieProviderCustomizer.class)
     @Import({
             ContentGridCurieConfiguration.class,
@@ -45,10 +51,9 @@ public class ContentGridSpringDataRestAutoConfiguration {
 
     }
 
-    @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(RestConfiguration.class)
+    @ConditionalOnBean(type = "org.springframework.content.commons.storeservice.Stores")
     @Import(ContentGridSpringContentRestLinksConfiguration.class)
-    @AutoConfigureAfter(ContentGridSpringDataRestCurieAutoConfiguration.class)
     static class ContentGridSpringContentRestLinksAutoConfiguration {
 
     }

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -3,12 +3,15 @@ package com.contentgrid.spring.boot.autoconfigure.data.web;
 import com.contentgrid.spring.data.rest.affordances.ContentGridSpringDataRestAffordancesConfiguration;
 import com.contentgrid.spring.data.rest.hal.ContentGridCurieConfiguration;
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import com.contentgrid.spring.data.rest.links.ContentGridSpringContentRestLinksConfiguration;
+import com.contentgrid.spring.data.rest.links.ContentGridSpringDataLinksConfiguration;
 import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.hateoas.HypermediaAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.content.rest.config.RestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -16,12 +19,12 @@ import org.springframework.data.rest.webmvc.ContentGridRestProperties;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ContentGridSpringDataRestConfiguration.class, RepositoryRestMvcConfiguration.class})
 @Import({
         ContentGridSpringDataRestConfiguration.class,
         ContentGridSpringDataRestProfileConfiguration.class,
-        ContentGridSpringDataRestAffordancesConfiguration.class
+        ContentGridSpringDataRestAffordancesConfiguration.class,
 })
 @AutoConfigureAfter(HypermediaAutoConfiguration.class)
 public class ContentGridSpringDataRestAutoConfiguration {
@@ -32,9 +35,21 @@ public class ContentGridSpringDataRestAutoConfiguration {
         return new ContentGridRestProperties();
     }
 
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnBean(CurieProviderCustomizer.class)
-    @Import(ContentGridCurieConfiguration.class)
-    static class CurieAutoConfiguration {
+    @Import({
+            ContentGridCurieConfiguration.class,
+            ContentGridSpringDataLinksConfiguration.class
+    })
+    static class ContentGridSpringDataRestCurieAutoConfiguration {
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(RestConfiguration.class)
+    @Import(ContentGridSpringContentRestLinksConfiguration.class)
+    @AutoConfigureAfter(ContentGridSpringDataRestCurieAutoConfiguration.class)
+    static class ContentGridSpringContentRestLinksAutoConfiguration {
 
     }
 

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -42,6 +42,7 @@ public class ContentGridSpringDataRestAutoConfiguration {
         return new ContentGridRestProperties();
     }
 
+    @Configuration(proxyBeanMethods = false)
     @ConditionalOnBean(CurieProviderCustomizer.class)
     @Import({
             ContentGridCurieConfiguration.class,
@@ -49,13 +50,13 @@ public class ContentGridSpringDataRestAutoConfiguration {
     })
     static class ContentGridSpringDataRestCurieAutoConfiguration {
 
-    }
+        @Configuration(proxyBeanMethods = false)
+        @ConditionalOnClass(RestConfiguration.class)
+        @ConditionalOnBean(type = "org.springframework.content.commons.storeservice.Stores")
+        @Import(ContentGridSpringContentRestLinksConfiguration.class)
+        static class ContentGridSpringContentRestLinksAutoConfiguration {
 
-    @ConditionalOnClass(RestConfiguration.class)
-    @ConditionalOnBean(type = "org.springframework.content.commons.storeservice.Stores")
-    @Import(ContentGridSpringContentRestLinksConfiguration.class)
-    static class ContentGridSpringContentRestLinksAutoConfiguration {
-
+        }
     }
 
 }

--- a/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
+++ b/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
@@ -90,7 +90,17 @@ class ContentGridSpringDataRestAutoConfigurationTest {
     }
 
     @Test
-    void when_springContent_isPresentAndConfigured() {
+    void without_curieProviderCustomizer_when_springContent_isPresentAndConfigured() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(ContentRestAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("contentGridSpringContentLinkCollector");
+                    assertThat(context).hasNotFailed();
+                });
+    }
+
+    @Test
+    void with_curieProviderCustomizer_when_springContent_isPresentAndConfigured() {
         contextRunner
                 .withConfiguration(AutoConfigurations.of(ContentRestAutoConfiguration.class))
                 .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
@@ -101,7 +111,7 @@ class ContentGridSpringDataRestAutoConfigurationTest {
     }
 
     @Test
-    void when_springContent_isPresentAndUnconfigured() {
+    void with_curieProviderCustomizer_when_springContent_isPresentAndUnconfigured() {
         contextRunner
                 .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
                 .run(context -> {
@@ -111,7 +121,7 @@ class ContentGridSpringDataRestAutoConfigurationTest {
     }
 
     @Test
-    void when_springContent_isAbsent() {
+    void with_curieProviderCustomizer_when_springContent_isAbsent() {
         contextRunner
                 .withClassLoader(new FilteredClassLoader(RestConfiguration.class))
                 .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))

--- a/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
+++ b/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
@@ -3,12 +3,14 @@ package com.contentgrid.spring.boot.autoconfigure.data.web;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import internal.org.springframework.content.rest.boot.autoconfigure.ContentRestAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.data.rest.RepositoryRestMvcAutoConfiguration;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.content.rest.config.RestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
@@ -85,6 +87,37 @@ class ContentGridSpringDataRestAutoConfigurationTest {
         CurieProviderCustomizer myCurieProviderCustomizer() {
             return CurieProviderCustomizer.register("test", "https://test.invalid/{rel}");
         }
+    }
 
+    @Test
+    void when_springContent_isPresentAndConfigured() {
+        contextRunner
+                .withConfiguration(AutoConfigurations.of(ContentRestAutoConfiguration.class))
+                .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
+                .run(context -> {
+                    assertThat(context).hasBean("contentGridSpringContentLinkCollector");
+                    assertThat(context).hasNotFailed();
+                });
+    }
+
+    @Test
+    void when_springContent_isPresentAndUnconfigured() {
+        contextRunner
+                .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("contentGridSpringContentLinkCollector");
+                    assertThat(context).hasNotFailed();
+                });
+    }
+
+    @Test
+    void when_springContent_isAbsent() {
+        contextRunner
+                .withClassLoader(new FilteredClassLoader(RestConfiguration.class))
+                .withConfiguration(UserConfigurations.of(CurieCustomizerConfiguration.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean("contentGridSpringContentLinkCollector");
+                    assertThat(context).hasNotFailed();
+                });
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/AggregateLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/AggregateLinkCollector.java
@@ -1,0 +1,34 @@
+package com.contentgrid.spring.data.rest.links;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.rest.webmvc.mapping.LinkCollector;
+import org.springframework.hateoas.Links;
+
+@RequiredArgsConstructor
+class AggregateLinkCollector implements LinkCollector {
+    private final LinkCollector delegate;
+    private final Iterable<ContentGridLinkCollector> collectors;
+
+    @Override
+    public Links getLinksFor(Object object) {
+        return getLinksFor(object, Links.NONE);
+    }
+
+    @Override
+    public Links getLinksFor(Object object, Links existing) {
+        existing = delegate.getLinksFor(object, existing);
+        for (var collector : collectors) {
+            existing = collector.getLinksFor(object, existing);
+        }
+        return existing;
+    }
+
+    @Override
+    public Links getLinksForNested(Object object, Links existing) {
+        existing = delegate.getLinksFor(object, existing);
+        for (var collector : collectors) {
+            existing = collector.getLinksForNested(object, existing);
+        }
+        return existing;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkCollector.java
@@ -1,0 +1,10 @@
+package com.contentgrid.spring.data.rest.links;
+
+import org.springframework.hateoas.Links;
+
+public interface ContentGridLinkCollector {
+
+    Links getLinksFor(Object object, Links existing);
+
+    Links getLinksForNested(Object object, Links existing);
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkRelations.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkRelations.java
@@ -10,6 +10,7 @@ public class ContentGridLinkRelations {
     final static String CURIE = "cg";
     final static UriTemplate TEMPLATE = UriTemplate.of("https://contentgrid.com/rels/contentgrid/{rel}");
 
+    public final static LinkRelation ENTITY = HalLinkRelation.curied(CURIE, "entity");
     public final static LinkRelation RELATION = HalLinkRelation.curied(CURIE, "relation");
     public final static LinkRelation CONTENT = HalLinkRelation.curied(CURIE, "content");
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkRelations.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridLinkRelations.java
@@ -1,0 +1,16 @@
+package com.contentgrid.spring.data.rest.links;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.UriTemplate;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+
+@UtilityClass
+public class ContentGridLinkRelations {
+    final static String CURIE = "cg";
+    final static UriTemplate TEMPLATE = UriTemplate.of("https://contentgrid.com/rels/contentgrid/{rel}");
+
+    public final static LinkRelation RELATION = HalLinkRelation.curied(CURIE, "relation");
+    public final static LinkRelation CONTENT = HalLinkRelation.curied(CURIE, "content");
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringContentRestLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringContentRestLinksConfiguration.java
@@ -1,0 +1,21 @@
+package com.contentgrid.spring.data.rest.links;
+
+import internal.org.springframework.content.rest.mappingcontext.ContentPropertyToLinkrelMappingContext;
+import internal.org.springframework.content.rest.mappingcontext.ContentPropertyToRequestMappingContext;
+import org.springframework.content.commons.mappingcontext.MappingContext;
+import org.springframework.content.commons.storeservice.Stores;
+import org.springframework.content.rest.config.RestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.mapping.context.PersistentEntities;
+
+@Configuration(proxyBeanMethods = false)
+@Import(ContentGridSpringDataLinksConfiguration.class)
+public class ContentGridSpringContentRestLinksConfiguration {
+    @Bean
+    ContentGridLinkCollector contentGridSpringContentLinkCollector(
+            PersistentEntities entities, Stores stores, MappingContext mappingContext, RestConfiguration restConfiguration, ContentPropertyToRequestMappingContext requestMappingContext, ContentPropertyToLinkrelMappingContext linkrelMappingContext) {
+        return new SpringContentLinkCollector(entities, stores, mappingContext, restConfiguration, requestMappingContext, linkrelMappingContext);
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -1,0 +1,36 @@
+package com.contentgrid.spring.data.rest.links;
+
+import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.rest.core.support.SelfLinkProvider;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
+import org.springframework.data.rest.webmvc.mapping.Associations;
+import org.springframework.data.rest.webmvc.mapping.LinkCollector;
+
+@Configuration(proxyBeanMethods = false)
+public class ContentGridSpringDataLinksConfiguration {
+    @Bean
+    RepositoryRestConfigurer contentGridLinkCollectorConfigurer(
+            ObjectProvider<ContentGridLinkCollector> collectors
+    ) {
+        return new RepositoryRestConfigurer() {
+            @Override
+            public LinkCollector customizeLinkCollector(LinkCollector collector) {
+                return new AggregateLinkCollector(collector, collectors);
+            }
+        };
+    }
+
+    @Bean
+    ContentGridLinkCollector contentGridRelationLinkCollector(PersistentEntities entities, Associations associations, SelfLinkProvider selfLinkProvider) {
+        return new SpringDataAssociationLinkCollector(entities, associations, selfLinkProvider);
+    }
+
+    @Bean
+    CurieProviderCustomizer contentGridCurieProviderCustomizer() {
+        return CurieProviderCustomizer.register(ContentGridLinkRelations.CURIE, ContentGridLinkRelations.TEMPLATE);
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -5,10 +5,15 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.mapping.LinkCollector;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 
 @Configuration(proxyBeanMethods = false)
 public class ContentGridSpringDataLinksConfiguration {
@@ -32,5 +37,10 @@ public class ContentGridSpringDataLinksConfiguration {
     @Bean
     CurieProviderCustomizer contentGridCurieProviderCustomizer() {
         return CurieProviderCustomizer.register(ContentGridLinkRelations.CURIE, ContentGridLinkRelations.TEMPLATE);
+    }
+
+    @Bean
+    RepresentationModelProcessor<RepositoryLinksResource> contentGridRepositoryLinksResourceProcessor(Repositories repositories, ResourceMappings resourceMappings, EntityLinks entityLinks) {
+        return new SpringDataRepositoryLinksResourceProcessor(repositories, resourceMappings, entityLinks);
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -1,14 +1,17 @@
 package com.contentgrid.spring.data.rest.links;
 
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import com.contentgrid.spring.data.rest.webmvc.ProfileLinksResource;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.rest.webmvc.RestControllerConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.mapping.LinkCollector;
@@ -42,5 +45,10 @@ public class ContentGridSpringDataLinksConfiguration {
     @Bean
     RepresentationModelProcessor<RepositoryLinksResource> contentGridRepositoryLinksResourceProcessor(Repositories repositories, ResourceMappings resourceMappings, EntityLinks entityLinks) {
         return new SpringDataRepositoryLinksResourceProcessor(repositories, resourceMappings, entityLinks);
+    }
+
+    @Bean
+    RepresentationModelProcessor<ProfileLinksResource> contentGridProfileLinksResourceProcessor(Repositories repositories, ResourceMappings resourceMappings, RepositoryRestConfiguration configuration) {
+        return new SpringDataProfileLinksResourceProcessor(repositories, resourceMappings, configuration);
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringContentLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringContentLinkCollector.java
@@ -1,0 +1,97 @@
+package com.contentgrid.spring.data.rest.links;
+
+import internal.org.springframework.content.rest.links.ContentLinksResourceProcessor.StoreLinkBuilder;
+import internal.org.springframework.content.rest.mappingcontext.ContentPropertyToLinkrelMappingContext;
+import internal.org.springframework.content.rest.mappingcontext.ContentPropertyToRequestMappingContext;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Map.Entry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.content.commons.mappingcontext.ContentProperty;
+import org.springframework.content.commons.mappingcontext.MappingContext;
+import org.springframework.content.commons.repository.AssociativeStore;
+import org.springframework.content.commons.storeservice.Stores;
+import org.springframework.content.rest.config.RestConfiguration;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.rest.webmvc.BaseUri;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.Links;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.util.StringUtils;
+
+/**
+ * Collects links to spring-content content objects into the {@link ContentGridLinkRelations#CONTENT} link-relation
+ */
+@RequiredArgsConstructor
+class SpringContentLinkCollector implements ContentGridLinkCollector {
+    private final PersistentEntities entities;
+    private final Stores stores;
+    private final MappingContext mappingContext;
+    private final RestConfiguration restConfiguration;
+    private final ContentPropertyToRequestMappingContext requestMappingContext;
+    private final ContentPropertyToLinkrelMappingContext linkrelMappingContext;
+
+    @Override
+    public Links getLinksFor(Object object, Links existing) {
+        // This implementation is inspired on the ContentLinksResourceProcessor from spring-content, but adapted to the context of a LinkCollector
+
+        var persistentEntity = entities.getRequiredPersistentEntity(object.getClass());
+
+        var entityId = persistentEntity.getIdentifierAccessor(object).getIdentifier();
+
+        if(entityId == null) {
+            // No entity ID, so no content links (because they reference the entity ID)
+            return existing;
+        }
+
+        var storeInfo = stores.getStore(AssociativeStore.class, Stores.withDomainClass(persistentEntity.getType()));
+        if(storeInfo == null) {
+            // No store, we don't have to add any links
+            return existing;
+        }
+
+        Map<String, ContentProperty> contentProperties = mappingContext.getContentPropertyMap(persistentEntity.getType());
+
+        var links = new ArrayList<Link>(contentProperties.size());
+
+        for (Entry<String, ContentProperty> contentProperty : contentProperties.entrySet()) {
+            var linkBuilder = StoreLinkBuilder.linkTo(new BaseUri(restConfiguration.getBaseUri()), storeInfo);
+            linkBuilder = linkBuilder.slash(entityId);
+
+            String requestMapping = requestMappingContext.getMappings(storeInfo.getDomainObjectClass()).get(contentProperty.getKey());
+
+            if(StringUtils.hasText(requestMapping)) {
+                linkBuilder = linkBuilder.slash(requestMapping);
+            } else {
+                linkBuilder = linkBuilder.slash(contentProperty.getKey());
+            }
+
+            String linkRel = linkrelMappingContext.getMappings(storeInfo.getDomainObjectClass()).get(contentProperty.getKey());
+            if(!StringUtils.hasLength(linkRel)) {
+                linkRel = contentProperty.getKey();
+            }
+            // Cut off a potential CURIE prefix from the link relation
+            var linkName = HalLinkRelation.of(LinkRelation.of(linkRel)).getLocalPart();
+
+
+            var link = linkBuilder
+                    .withRel(ContentGridLinkRelations.CONTENT)
+                    .withName(linkName);
+
+//            var mimeType = contentProperty.getValue().getMimeType(object);
+//            if(mimeType != null) {
+//                link = link.withType(String.valueOf(mimeType));
+//            }
+            links.add(link);
+        }
+
+
+        return existing.and(links);
+    }
+
+    @Override
+    public Links getLinksForNested(Object object, Links existing) {
+        return existing;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
@@ -1,0 +1,68 @@
+package com.contentgrid.spring.data.rest.links;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.SimpleAssociationHandler;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.rest.core.Path;
+import org.springframework.data.rest.core.support.SelfLinkProvider;
+import org.springframework.data.rest.webmvc.mapping.Associations;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.Links;
+
+/**
+ * Collects links to jpa relations in the {@link ContentGridLinkRelations#RELATION} link-relation
+ */
+@RequiredArgsConstructor
+class SpringDataAssociationLinkCollector implements ContentGridLinkCollector {
+    private final PersistentEntities entities;
+    private final Associations associationLinks;
+    private final SelfLinkProvider selfLinkProvider;
+
+    @Override
+    public Links getLinksFor(Object object, Links existing) {
+        // Logic based on the DefaultLinkCollector from spring-data-rest
+        var selfLink = selfLinkProvider.createSelfLinkFor(object);
+
+        if(selfLink == null) {
+            return existing;
+        }
+
+        Path selfPath = new Path(selfLink.expand().getHref());
+
+        var links = new ArrayList<Link>();
+
+        entities.getRequiredPersistentEntity(object.getClass()).doWithAssociations(
+                (SimpleAssociationHandler) association -> {
+                    if(!associationLinks.isLinkableAssociation(association)) {
+                        return;
+                    }
+
+                    var property = association.getInverse();
+                    var linkName = readLinkName(property);
+
+                    for (Link link : associationLinks.getLinksFor(association, selfPath)) {
+                        links.add(link.withRel(ContentGridLinkRelations.RELATION).withName(linkName));
+                    }
+                });
+
+        return existing.and(links);
+    }
+
+    @Override
+    public Links getLinksForNested(Object object, Links existing) {
+        return existing;
+    }
+
+    private String readLinkName(PersistentProperty<?> property) {
+        var jsonProperty = property.findAnnotation(JsonProperty.class);
+        if(jsonProperty != null && !Objects.equals(jsonProperty.value(), JsonProperty.USE_DEFAULT_NAME)) {
+            return jsonProperty.value();
+        }
+        return property.getName();
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessor.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessor.java
@@ -1,0 +1,35 @@
+package com.contentgrid.spring.data.rest.links;
+
+import com.contentgrid.spring.data.rest.webmvc.ProfileLinksResource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.core.mapping.ResourceMappings;
+import org.springframework.data.rest.webmvc.ProfileController;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+
+@RequiredArgsConstructor
+public class SpringDataProfileLinksResourceProcessor implements RepresentationModelProcessor<ProfileLinksResource> {
+    private final Repositories repositories;
+    private final ResourceMappings mappings;
+    private final RepositoryRestConfiguration configuration;
+
+    @Override
+    public ProfileLinksResource process(ProfileLinksResource model) {
+        for (Class<?> domainType : repositories) {
+            var metadata = mappings.getMetadataFor(domainType);
+            if(metadata.isExported()) {
+                model.add(
+                        Link.of(ProfileController.getPath(configuration, metadata))
+                                .withRel(ContentGridLinkRelations.ENTITY)
+                                .withName(HalLinkRelation.of(metadata.getRel()).getLocalPart())
+                );
+
+            }
+
+        }
+        return model;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessor.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessor.java
@@ -1,0 +1,35 @@
+package com.contentgrid.spring.data.rest.links;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.support.Repositories;
+import org.springframework.data.rest.core.mapping.ResourceMappings;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+
+@RequiredArgsConstructor
+public class SpringDataRepositoryLinksResourceProcessor implements RepresentationModelProcessor<RepositoryLinksResource> {
+    private final Repositories repositories;
+    private final ResourceMappings mappings;
+    private final EntityLinks entityLinks;
+
+    @Override
+    public RepositoryLinksResource process(RepositoryLinksResource model) {
+        for (Class<?> domainType : repositories) {
+            var metadata = mappings.getMetadataFor(domainType);
+            if(metadata.isExported()) {
+                var collectionLink = entityLinks.linkToCollectionResource(domainType);
+
+                model.add(
+                        collectionLink
+                                .withRel(ContentGridLinkRelations.ENTITY)
+                                .withName(HalLinkRelation.of(collectionLink.getRel()).getLocalPart())
+                );
+
+            }
+
+        }
+        return model;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/ProfileLinksResource.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/ProfileLinksResource.java
@@ -1,0 +1,7 @@
+package com.contentgrid.spring.data.rest.webmvc;
+
+import org.springframework.hateoas.RepresentationModel;
+
+public class ProfileLinksResource extends RepresentationModel<ProfileLinksResource> {
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
@@ -12,7 +12,7 @@ import org.springframework.data.rest.core.mapping.RepositoryResourceMappings;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class ContentGridSpringDataRestConfiguration {
 
     @Bean

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
@@ -35,6 +35,19 @@ public class ContentGridSpringDataRestConfiguration {
             }
         };
     }
+    
+    @Bean
+    public BeanPostProcessor replaceProfileController() {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if(bean instanceof ProfileController delegate) {
+                    return new DelegatingProfileController(delegate);
+                }
+                return bean;
+            }
+        };
+    }
 
     @Bean
     public ContentRestConfigurer contentRestConfigurer() {

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingProfileController.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingProfileController.java
@@ -1,0 +1,35 @@
+package org.springframework.data.rest.webmvc;
+
+import static org.springframework.data.rest.webmvc.ProfileController.PROFILE_ROOT_MAPPING;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import com.contentgrid.spring.data.rest.webmvc.ProfileLinksResource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@BasePathAwareController
+@RequiredArgsConstructor
+public class DelegatingProfileController {
+    private final ProfileController delegate;
+
+    @RequestMapping(value = PROFILE_ROOT_MAPPING, method = RequestMethod.OPTIONS)
+    public HttpEntity<?> profileOptions() {
+        return delegate.profileOptions();
+    }
+
+    @RequestMapping(value = PROFILE_ROOT_MAPPING, method = GET)
+    public HttpEntity<ProfileLinksResource> listAllFormsOfMetadata() {
+        var resource = new ProfileLinksResource();
+        var originalModel = delegate.listAllFormsOfMetadata();
+
+        resource.add(originalModel.getBody().getLinks().toList());
+
+        return ResponseEntity.ok()
+                .headers(originalModel.getHeaders())
+                .body(resource);
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingProfileController.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingProfileController.java
@@ -25,6 +25,8 @@ public class DelegatingProfileController {
         var resource = new ProfileLinksResource();
         var originalModel = delegate.listAllFormsOfMetadata();
 
+        // The change from the spring-data-rest ProfileController is returning a specific ProfileLinksResource.
+        // This specific resource class can be used by a RepresentationModelProcessor to further enhance the response.
         resource.add(originalModel.getBody().getLinks().toList());
 
         return ResponseEntity.ok()

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieConfigurationTest.java
@@ -22,7 +22,6 @@ import org.springframework.test.context.ContextConfiguration;
         ContentGridCurieConfiguration.class,
         CurieProviderCustomizers.class
 })
-@AutoConfigureMockMvc(printOnlyOnFailure = false)
 class ContentGridCurieConfigurationTest {
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringContentLinkCollectorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringContentLinkCollectorTest.java
@@ -1,0 +1,61 @@
+package com.contentgrid.spring.data.rest.links;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.Links;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class
+})
+class SpringContentLinkCollectorTest {
+    @Autowired
+    SpringContentLinkCollector linkCollector;
+
+    @Test
+    void contentLinksForDirect() {
+        var entity = new Invoice();
+        entity.setId(UUID.randomUUID());
+
+        assertThat(linkCollector.getLinksFor(entity, Links.NONE))
+                .allSatisfy(link -> {
+                    assertThat(link.getRel()).isEqualTo(ContentGridLinkRelations.CONTENT);
+                })
+                .satisfiesExactlyInAnyOrder(
+                        link -> {
+                            assertThat(link.getName()).isEqualTo("content");
+                            assertThat(link.getHref()).isEqualTo("http://localhost/invoices/%s/content".formatted(entity.getId()));
+                        },
+                        link -> {
+                            assertThat(link.getName()).isEqualTo("attachment");
+                            assertThat(link.getHref()).isEqualTo("http://localhost/invoices/%s/attachment".formatted(entity.getId()));
+                        }
+                );
+    }
+
+    @Test
+    void contentLinksForEmbedded() {
+        var entity = new Customer();
+        entity.setId(UUID.randomUUID());
+
+        assertThat(linkCollector.getLinksFor(entity, Links.NONE))
+                .allSatisfy(link -> {
+                    assertThat(link.getRel()).isEqualTo(ContentGridLinkRelations.CONTENT);
+                })
+                .satisfiesExactlyInAnyOrder(
+                        link -> {
+                            assertThat(link.getName()).isEqualTo("content");
+                            assertThat(link.getHref()).isEqualTo("http://localhost/customers/%s/content".formatted(entity.getId()));
+                        }
+                );
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollectorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollectorTest.java
@@ -1,0 +1,59 @@
+package com.contentgrid.spring.data.rest.links;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.ShippingAddress;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.Links;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class
+})
+class SpringDataAssociationLinkCollectorTest {
+    @Autowired
+    SpringDataAssociationLinkCollector associationLinkCollector;
+
+    @Test
+    void associationLinksForToOne() {
+        var entity = new ShippingAddress();
+        entity.setId(UUID.randomUUID());
+
+        assertThat(associationLinkCollector.getLinksFor(entity, Links.NONE))
+                .allSatisfy(link -> {
+                    assertThat(link.getRel()).isEqualTo(ContentGridLinkRelations.RELATION);
+                })
+                .satisfiesExactlyInAnyOrder(link -> {
+                    assertThat(link.getName()).isEqualTo("order");
+                    assertThat(link.getHref()).isEqualTo("http://localhost/shipping-addresses/%s/order".formatted(entity.getId()));
+                });
+    }
+
+    @Test
+    void associationLinksForToMany() {
+        var entity = new Customer();
+        entity.setId(UUID.randomUUID());
+
+        assertThat(associationLinkCollector.getLinksFor(entity, Links.NONE))
+                .allSatisfy(link -> {
+                    assertThat(link.getRel()).isEqualTo(ContentGridLinkRelations.RELATION);
+                })
+                .satisfiesExactlyInAnyOrder(
+                        link -> {
+                            assertThat(link.getName()).isEqualTo("orders");
+                            assertThat(link.getHref()).isEqualTo("http://localhost/customers/%s/orders".formatted(entity.getId()));
+                        },
+                        link -> {
+                            assertThat(link.getName()).isEqualTo("invoices");
+                            assertThat(link.getHref()).isEqualTo("http://localhost/customers/%s/invoices".formatted(entity.getId()));
+                        }
+                );
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessorTest.java
@@ -1,0 +1,57 @@
+package com.contentgrid.spring.data.rest.links;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class
+})
+@AutoConfigureMockMvc
+class SpringDataProfileLinksResourceProcessorTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void entityLinkRelAddedToProfile() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/profile"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            _links: {
+                                "cg:entity": [
+                                    {
+                                        name: "customers",
+                                        href: "http://localhost/profile/customers"
+                                    },
+                                    {
+                                        name: "invoices",
+                                        href: "http://localhost/profile/invoices"
+                                    },
+                                    {
+                                        name: "orders",
+                                        href: "http://localhost/profile/orders"
+                                    },
+                                    {
+                                        name: "promotions",
+                                        href: "http://localhost/profile/promotions"
+                                    },
+                                    {
+                                        name: "shipping-addresses",
+                                        href: "http://localhost/profile/shipping-addresses"
+                                    }
+                                ]
+                            }
+                        }
+                        """));
+    }
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessorTest.java
@@ -1,0 +1,61 @@
+package com.contentgrid.spring.data.rest.links;
+
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class
+})
+@AutoConfigureMockMvc
+class SpringDataRepositoryLinksResourceProcessorTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void entityLinkRelAddedToRoot() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        {
+                            _links: {
+                                "cg:entity": [
+                                    {
+                                        name: "customers",
+                                        href: "http://localhost/customers{?page,size,sort}",
+                                        templated: true
+                                    },
+                                    {
+                                        name: "invoices",
+                                        href: "http://localhost/invoices{?page,size,sort}",
+                                        templated: true
+                                    },
+                                    {
+                                        name: "orders",
+                                        href: "http://localhost/orders{?page,size,sort}",
+                                        templated: true
+                                    },
+                                    {
+                                        name: "promotions",
+                                        href: "http://localhost/promotions{?page,size,sort}",
+                                        templated: true
+                                    },
+                                    {
+                                        name: "shipping-addresses",
+                                        href: "http://localhost/shipping-addresses{?page,size,sort}",
+                                        templated: true
+                                    }
+                                ]
+                            }
+                        }
+                        """));
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/store/CustomerContentStore.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/store/CustomerContentStore.java
@@ -1,0 +1,10 @@
+package com.contentgrid.spring.test.fixture.invoicing.store;
+
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import org.springframework.content.commons.repository.ContentStore;
+import org.springframework.content.rest.StoreRestResource;
+
+@StoreRestResource
+public interface CustomerContentStore extends ContentStore<Customer, String> {
+
+}


### PR DESCRIPTION
These generic link relations: `cg:entity`, `cg:relation` & `cg:content` can be used to build generic integrations that are independent of the datamodel of the application.

Such a generic application can now easily read all content properties from an entity without relying on heuristics to determine which link-relations on an entity object are content and which ones are other relations.

Similarly, a generic application can now discover all available entity types from `/` (or their profiles from `/profile`) by using the `cg:entity` relation, instead of reading all relations and assuming which ones are entities based on heuristics.

Since the generic link relations rely on CURIEs so they are namespaced, they are only activated when a `CurieProviderCustomizer` is defined (and thus when all custom links based on the datamodel are being prefixed)
