### PR TITLE
Use 'item' link-rel for collection `_embedded` items

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -11,10 +11,10 @@ import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.data.rest.core.mapping.ResourceMappings;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
-import org.springframework.data.rest.webmvc.RestControllerConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.mapping.LinkCollector;
+import org.springframework.hateoas.CollectionModel;
 import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 
@@ -50,5 +50,10 @@ public class ContentGridSpringDataLinksConfiguration {
     @Bean
     RepresentationModelProcessor<ProfileLinksResource> contentGridProfileLinksResourceProcessor(Repositories repositories, ResourceMappings resourceMappings, RepositoryRestConfiguration configuration) {
         return new SpringDataProfileLinksResourceProcessor(repositories, resourceMappings, configuration);
+    }
+
+    @Bean
+    RepresentationModelProcessor<CollectionModel<?>> contentGridSpringDataEmbeddedItemResourceProcessor() {
+        return new SpringDataEmbeddedItemResourceProcessor();
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedItemResourceProcessor.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedItemResourceProcessor.java
@@ -43,7 +43,9 @@ public class SpringDataEmbeddedItemResourceProcessor implements RepresentationMo
                     return wrappers.wrap(content, IanaLinkRelations.ITEM);
                 });
 
-        return createModelCopy(model, List.of(wrapper));
+        return createModelCopy(model, List.of(wrapper))
+                .add(model.getLinks())
+                .withFallbackType(model.getResolvableType());
     }
 
     private CollectionModel<?> createModelCopy(CollectionModel<?> model, Iterable<?> content) {

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedItemResourceProcessor.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedItemResourceProcessor.java
@@ -1,0 +1,150 @@
+package com.contentgrid.spring.data.rest.links;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.PagedModel.PageMetadata;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.core.EmbeddedWrapper;
+import org.springframework.hateoas.server.core.EmbeddedWrappers;
+import org.springframework.lang.Nullable;
+
+/**
+ * Changes the link-relation for items in a collection to 'item'.
+ * <p>
+ * This processor must run with highest precedence, so it executes before any other resource processors that may add
+ * additional {@link EmbeddedWrapper}s to the resource.
+ */
+@RequiredArgsConstructor
+public class SpringDataEmbeddedItemResourceProcessor implements RepresentationModelProcessor<CollectionModel<?>>,
+        Ordered {
+
+    private final EmbeddedWrappers wrappers = new EmbeddedWrappers(true);
+
+    @Override
+    public CollectionModel<?> process(CollectionModel<?> model) {
+        var content = model.getContent();
+
+        var wrapper = findEmptyWrapper(content)
+                .<EmbeddedWrapper>map(w -> new ForcedLinkRelEmbeddedWrapper(w, IanaLinkRelations.ITEM))
+                .orElseGet(() -> {
+                    if (hasWrappers(content)) {
+                        throw new UnsupportedOperationException(
+                                "Model is already wrapped; cannot identify the primary collection to set up the 'item' collection");
+                    }
+                    return wrappers.wrap(content, IanaLinkRelations.ITEM);
+                });
+
+        return createModelCopy(model, List.of(wrapper));
+    }
+
+    private CollectionModel<?> createModelCopy(CollectionModel<?> model, Iterable<?> content) {
+        if (model instanceof PagedModel<?> pagedModel) {
+            return new PageModel<>(content, pagedModel.getMetadata());
+        } else {
+            return CollectionModel.of(content);
+        }
+    }
+
+    private boolean hasWrappers(Collection<?> collection) {
+        for (Object item : collection) {
+            if (item instanceof EmbeddedWrapper) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Optional<EmbeddedWrapper> findEmptyWrapper(Collection<?> collection) {
+        if (collection.size() != 1) {
+            return Optional.empty();
+        }
+        if (collection.stream().findAny().orElseThrow() instanceof EmbeddedWrapper embeddedWrapper) {
+            if (embeddedWrapper.getValue() instanceof Collection<?> embeddedCollection) {
+                if (embeddedCollection.isEmpty()) {
+                    return Optional.of(embeddedWrapper);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    private Collection<EmbeddedWrapper> ensureWrapped(Collection<?> content) {
+        List<EmbeddedWrapper> allWrappers = new ArrayList<>();
+        List<Object> unwrapped = new ArrayList<>();
+        for (Object item : content) {
+            if (item instanceof EmbeddedWrapper wrapper) {
+                allWrappers.add(wrapper);
+            } else {
+                unwrapped.add(item);
+            }
+        }
+
+        if (!unwrapped.isEmpty()) {
+            allWrappers.add(wrappers.wrap(unwrapped, IanaLinkRelations.ITEM));
+        }
+
+        return allWrappers;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.HIGHEST_PRECEDENCE;
+    }
+
+    private static class PageModel<T> extends CollectionModel<T> {
+
+        private final PageMetadata pageMetadata;
+
+        private PageModel(Iterable<T> content, PageMetadata pageMetadata) {
+            super(content);
+            this.pageMetadata = pageMetadata;
+        }
+
+        @JsonProperty("page")
+        @Nullable
+        public PageMetadata getMetadata() {
+            return pageMetadata;
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class ForcedLinkRelEmbeddedWrapper implements EmbeddedWrapper {
+
+        private final EmbeddedWrapper delegate;
+        private final LinkRelation linkRelation;
+
+        @Override
+        public Optional<LinkRelation> getRel() {
+            return Optional.of(linkRelation);
+        }
+
+        @Override
+        public boolean hasRel(LinkRelation rel) {
+            return linkRelation.isSameAs(rel);
+        }
+
+        @Override
+        public boolean isCollectionValue() {
+            return delegate.isCollectionValue();
+        }
+
+        @Override
+        public Object getValue() {
+            return delegate.getValue();
+        }
+
+        @Override
+        public Class<?> getRelTargetType() {
+            return delegate.getRelTargetType();
+        }
+    }
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -95,7 +95,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                 .andExpect(MockMvcResultMatchers.content().json("""
                         {
                             _embedded: {
-                                "d:customers": [
+                                "item": [
                                     {
                                         _links: {
                                             self: {
@@ -137,7 +137,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                 // No top-level _templates are present
                 .andExpect(MockMvcResultMatchers.jsonPath("$.keys()", Matchers.not(Matchers.contains("_templates"))))
                 // The templates of the embedded object only contain a default and a delete template
-                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.['d:customers'][0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.['item'][0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
         ;
     }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataProfileLinksResourceProcessorTest.java
@@ -48,6 +48,10 @@ class SpringDataProfileLinksResourceProcessorTest {
                                     {
                                         name: "shipping-addresses",
                                         href: "http://localhost/profile/shipping-addresses"
+                                    },
+                                    {
+                                        name: "refunds",
+                                        href: "http://localhost/profile/refunds"
                                     }
                                 ]
                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataRepositoryLinksResourceProcessorTest.java
@@ -51,6 +51,11 @@ class SpringDataRepositoryLinksResourceProcessorTest {
                                         name: "shipping-addresses",
                                         href: "http://localhost/shipping-addresses{?page,size,sort}",
                                         templated: true
+                                    },
+                                    {
+                                        name: "refunds",
+                                        href: "http://localhost/refunds{?page,size,sort}",
+                                        templated: true
                                     }
                                 ]
                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -143,7 +143,8 @@ class InvoicingApplicationTests {
                 mockMvc.perform(get("/invoices")
                                 .contentType("application/json"))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.['d:invoices'].length()").value(2));
+                        .andExpect(jsonPath("$._embedded.['item'].length()").value(2))
+                        .andExpect(jsonPath("$._embedded.['item'][0].number").exists());
             }
         }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -146,6 +146,13 @@ class InvoicingApplicationTests {
                         .andExpect(jsonPath("$._embedded.['item'].length()").value(2))
                         .andExpect(jsonPath("$._embedded.['item'][0].number").exists());
             }
+
+            @Test
+            void listRefunds_returns_http200_ok() throws Exception {
+                mockMvc.perform(get("/refunds").contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.['item'].length()").value(0));
+            }
         }
 
         @Nested

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -144,14 +144,16 @@ class InvoicingApplicationTests {
                                 .contentType("application/json"))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$._embedded.['item'].length()").value(2))
-                        .andExpect(jsonPath("$._embedded.['item'][0].number").exists());
+                        .andExpect(jsonPath("$._embedded.['item'][0].number").exists())
+                        .andExpect(jsonPath("$._links.self.href").value("http://localhost/invoices"));
             }
 
             @Test
             void listRefunds_returns_http200_ok() throws Exception {
                 mockMvc.perform(get("/refunds").contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk())
-                        .andExpect(jsonPath("$._embedded.['item'].length()").value(0));
+                        .andExpect(jsonPath("$._embedded.['item'].length()").value(0))
+                        .andExpect(jsonPath("$._links.self.href").value("http://localhost/refunds"));
             }
         }
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Refund.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Refund.java
@@ -1,0 +1,31 @@
+package com.contentgrid.spring.test.fixture.invoicing.model;
+
+import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import java.util.UUID;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Refund {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonProperty(access = Access.READ_ONLY)
+    private UUID id;
+
+    @OneToOne
+    @CollectionFilterParam
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:invoice")
+    private Invoice invoice;
+
+}

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/RefundRepository.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/repository/RefundRepository.java
@@ -1,0 +1,12 @@
+package com.contentgrid.spring.test.fixture.invoicing.repository;
+
+import com.contentgrid.spring.test.fixture.invoicing.model.Refund;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(itemResourceRel = "d:refund", collectionResourceRel = "d:refunds")
+public interface RefundRepository extends JpaRepository<Refund, UUID>, QuerydslPredicateExecutor<Refund> {
+
+}


### PR DESCRIPTION
- Use 'item' as link-relation for collection resources
- Add 'Refund' model to fixture application
- Ensure that links are present on the copied model
