### PR TITLE
Configure flyway to disable transactional lock

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/build.gradle
+++ b/contentgrid-spring-boot-autoconfigure/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     compileOnly "com.github.paulcwarren:spring-content-rest"
     compileOnly 'org.springframework.data:spring-data-rest-webmvc'
     compileOnly 'jakarta.persistence:jakarta.persistence-api'
+    compileOnly 'org.flywaydb:flyway-core'
 
     testImplementation project(':contentgrid-spring-integration-events')
     testImplementation project(':contentgrid-spring-data-rest')

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/flyway/FlywayPostgresAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/flyway/FlywayPostgresAutoConfiguration.java
@@ -1,0 +1,28 @@
+package com.contentgrid.spring.boot.autoconfigure.flyway;
+
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.internal.database.postgresql.PostgreSQLConfigurationExtension;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+
+@AutoConfiguration
+@AutoConfigureBefore(FlywayAutoConfiguration.class)
+@ConditionalOnClass({Flyway.class, PostgreSQLConfigurationExtension.class})
+public class FlywayPostgresAutoConfiguration {
+
+    /**
+     * The Flyway default of transactional lock enabled conflicts with 'CREATE INDEX CONCURRENTLY' migrations, so it should be disabled by default.
+     *
+     * @see <a href="https://documentation.red-gate.com/fd/postgresql-transactional-lock-184127530.html">Flyway documentation<a>
+     */
+    @Bean
+    FlywayConfigurationCustomizer postgresqlFlywayConfigurationCustomizerDisableTransactionalLock() {
+        return configuration -> {
+            configuration.getPluginRegister().getPlugin(PostgreSQLConfigurationExtension.class).setTransactionalLock(false);
+        };
+    }
+}


### PR DESCRIPTION
There are some changes made in Flyway between the version shipped in Spring Boot 2 & 3
A default was changed in flyway which results in `CREATE INDEX CONCURRENTLY` in a migration deadlocking during startup

The resolution provided in https://github.com/flyway/flyway/issues/3508 is to set a configuration option for transactional lock to false.
