### PR TITLE
Replace spring data QuerydslBinder with CollectionFilter-based search filters

### DIFF
--- a/contentgrid-spring-boot-platform/build.gradle
+++ b/contentgrid-spring-boot-platform/build.gradle
@@ -10,7 +10,7 @@ javaPlatform {
 
 dependencies {
     api platform('org.springframework.boot:spring-boot-dependencies:3.1.3')
-    api platform('com.contentgrid.thunx:thunx-bom:0.8.0')
+    api platform('com.contentgrid.thunx:thunx-bom:0.8.1-SNAPSHOT')
     api platform('com.github.paulcwarren:spring-content-bom:3.0.5')
 
     constraints {

--- a/contentgrid-spring-data-rest/build.gradle
+++ b/contentgrid-spring-data-rest/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 
     implementation 'org.springframework.data:spring-data-rest-webmvc'
     implementation 'com.github.paulcwarren:spring-content-rest'
+    implementation 'com.contentgrid.thunx:spring-data-querydsl-predicate-injector'
 
     implementation project(':contentgrid-spring-querydsl')
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersImpl.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersImpl.java
@@ -3,6 +3,7 @@ package com.contentgrid.spring.data.querydsl.mapping;
 import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +14,11 @@ class CollectionFiltersImpl extends AbstractCollectionFiltersImpl {
     @Override
     public Stream<CollectionFilter> filters() {
         return filters.values().stream();
+    }
+
+    @Override
+    public Optional<CollectionFilter> named(String filterName) {
+        return Optional.ofNullable(filters.get(filterName));
     }
 
 }

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
@@ -2,7 +2,9 @@ package org.springframework.data.rest.webmvc;
 
 import com.contentgrid.spring.data.querydsl.mapping.ContentGridCollectionFilterMappingConfiguration;
 import com.contentgrid.spring.data.querydsl.predicate.ContentGridCollectionFilterPredicateConfiguration;
+import com.contentgrid.spring.querydsl.resolver.CollectionFilterParamPredicateResolver;
 import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.rest.webmvc.QuerydslBindingsPredicateResolver;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.content.rest.config.ContentRestConfigurer;
@@ -10,6 +12,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
@@ -46,6 +49,22 @@ public class ContentGridSpringDataRestConfiguration {
             public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
                 if(bean instanceof ProfileController delegate) {
                     return new DelegatingProfileController(delegate);
+                }
+                return bean;
+            }
+        };
+    }
+
+    @Bean
+    public BeanPostProcessor replaceQuerydslWithCollectionFilterParamPredicateResolver(ApplicationContext applicationContext) {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if(bean instanceof QuerydslBindingsPredicateResolver) {
+                    return new CollectionFilterParamPredicateResolver(
+                            applicationContext.getBean(CollectionFiltersMapping.class),
+                            applicationContext.getBean("defaultConversionService", ConversionService.class)
+                    );
                 }
                 return bean;
             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -153,6 +153,15 @@ class InvoicingApplicationTests {
             }
 
             @Test
+            void listInvoices_withFilter_returns_http200_ok() throws Exception {
+                mockMvc.perform(get("/invoices?number={number}", INVOICE_NUMBER_1)
+                        .contentType("application/json"))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$._embedded.['item'].length()").value(1))
+                        .andExpect(jsonPath("$._embedded.['item'][0].number").value(INVOICE_NUMBER_1));
+            }
+
+            @Test
             void listRefunds_returns_http200_ok() throws Exception {
                 mockMvc.perform(get("/refunds").contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk())

--- a/contentgrid-spring-querydsl/build.gradle
+++ b/contentgrid-spring-querydsl/build.gradle
@@ -6,6 +6,9 @@ configurations {
     compileOnly {
         extendsFrom(annotationProcessor)
     }
+    testCompileOnly {
+        extendsFrom(testAnnotationProcessor)
+    }
 }
 
 dependencies {
@@ -13,7 +16,19 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     api platform(project(':contentgrid-spring-boot-platform'))
-    implementation platform(project(':contentgrid-spring-boot-platform'))
     api 'com.querydsl:querydsl-core'
+
+    implementation platform(project(':contentgrid-spring-boot-platform'))
     implementation 'org.springframework.data:spring-data-commons'
+    implementation 'com.contentgrid.thunx:spring-data-querydsl-predicate-injector'
+
+    testAnnotationProcessor platform(project(':contentgrid-spring-boot-platform'))
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params'
+    testImplementation 'org.assertj:assertj-core'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverter.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverter.java
@@ -1,0 +1,48 @@
+package com.contentgrid.spring.querydsl.converter;
+
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.ConversionService;
+
+@RequiredArgsConstructor
+public class CollectionFilterQuerydslPredicateConverter {
+    private final CollectionFiltersMapping collectionFiltersMapping;
+    private final ConversionService conversionService;
+
+    public Optional<Predicate> getPredicate(Class<?> domainType, Map<String, ? extends Collection<String>> parameters) {
+        var mapping = collectionFiltersMapping.forDomainType(domainType);
+
+        var predicateBuilder = new BooleanBuilder();
+
+        parameters.forEach((paramName, paramValues) -> {
+            mapping.named(paramName).ifPresent(filter -> {
+                Collection<?> typedParameters;
+                try {
+                     typedParameters = convertParametersToType(filter.getPath().getType(), paramValues);
+                } catch(ConversionFailedException e) {
+                    throw new InvalidCollectionFilterValueException(filter, (String)e.getValue(), e);
+                }
+                filter.createPredicate(typedParameters).ifPresent(predicateBuilder::and);
+            });
+        });
+
+        return Optional.ofNullable(predicateBuilder.getValue());
+    }
+
+    private Collection<?> convertParametersToType(Class<?> targetType, Collection<String> params) {
+        if(conversionService.canConvert(String.class, targetType)) {
+            return params.stream()
+                    .map(value -> conversionService.convert(value, targetType))
+                    .toList();
+        } else {
+            return params;
+        }
+    }
+
+}

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/converter/InvalidCollectionFilterValueException.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/converter/InvalidCollectionFilterValueException.java
@@ -1,0 +1,32 @@
+package com.contentgrid.spring.querydsl.converter;
+
+import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
+import lombok.Getter;
+import lombok.experimental.StandardException;
+
+public class InvalidCollectionFilterValueException extends RuntimeException {
+    @Getter
+    private final CollectionFilter filter;
+
+    @Getter
+    private final String invalidValue;
+
+    public InvalidCollectionFilterValueException(CollectionFilter filter, String invalidValue) {
+        super(createMessage(filter, invalidValue));
+        this.filter = filter;
+        this.invalidValue = invalidValue;
+    }
+
+    public InvalidCollectionFilterValueException(CollectionFilter filter, String invalidValue, Throwable cause) {
+        this(filter, invalidValue);
+        initCause(cause);
+    }
+
+    private static String createMessage(CollectionFilter filter, String invalidValue) {
+        return "Failed to convert value for filter '%s' to type '%s' for value [%s]".formatted(
+                filter.getFilterName(),
+                filter.getPath().getType(),
+                invalidValue
+        );
+    }
+}

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
@@ -1,11 +1,19 @@
 package com.contentgrid.spring.querydsl.mapping;
 
 import com.querydsl.core.types.Path;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 public interface CollectionFilters {
     Stream<CollectionFilter> filters();
 
-    CollectionFilters forPath(Path<?> path);
+    default CollectionFilters forPath(Path<?> path) {
+        return () -> CollectionFilters.this.filters().filter(filter -> Objects.equals(filter.getPath(), path));
+    }
+
+    default Optional<CollectionFilter> named(String filterName) {
+        return filters().filter(filter -> Objects.equals(filter.getFilterName(), filterName)).findAny();
+    };
 
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/resolver/CollectionFilterParamPredicateResolver.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/resolver/CollectionFilterParamPredicateResolver.java
@@ -1,0 +1,55 @@
+package com.contentgrid.spring.querydsl.resolver;
+
+import com.contentgrid.spring.querydsl.converter.CollectionFilterQuerydslPredicateConverter;
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.CollectionFilteringOperationPredicates;
+import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.OperationPredicates;
+import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.resolver.QuerydslPredicateResolver;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.data.querydsl.binding.QuerydslPredicate;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@RequiredArgsConstructor
+public class CollectionFilterParamPredicateResolver implements QuerydslPredicateResolver {
+
+    private final CollectionFilterQuerydslPredicateConverter querydslPredicateConverter;
+
+    public CollectionFilterParamPredicateResolver(CollectionFiltersMapping filtersMapping, ConversionService conversionService) {
+        this(new CollectionFilterQuerydslPredicateConverter(filtersMapping, conversionService));
+    }
+
+    @Override
+    public Optional<OperationPredicates> resolve(MethodParameter methodParameter, Class<?> domainType,
+            Map<String, String[]> parameters) {
+        if(!methodParameter.hasParameterAnnotation(QuerydslPredicate.class)) {
+            return Optional.empty();
+        }
+
+        return querydslPredicateConverter.getPredicate(domainType, toMultiValueMap(parameters))
+                .map(CollectionFilteringOperationPredicates::new);
+    }
+
+    /**
+     * Converts the given Map into a {@link MultiValueMap}.
+     *
+     * @param source must not be {@literal null}.
+     * @return the converted {@link MultiValueMap}.
+     */
+    private static MultiValueMap<String, String> toMultiValueMap(Map<String, String[]> source) {
+
+        MultiValueMap<String, String> result = new LinkedMultiValueMap<>();
+
+        for (Entry<String, String[]> entry : source.entrySet()) {
+            result.put(entry.getKey(), Arrays.asList(entry.getValue()));
+        }
+
+        return result;
+    }
+}

--- a/contentgrid-spring-querydsl/src/test/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverterTest.java
+++ b/contentgrid-spring-querydsl/src/test/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverterTest.java
@@ -1,0 +1,176 @@
+package com.contentgrid.spring.querydsl.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
+import com.contentgrid.spring.querydsl.mapping.CollectionFilters;
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.PathMetadata;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BeanPath;
+import com.querydsl.core.types.dsl.BooleanPath;
+import com.querydsl.core.types.dsl.ComparablePath;
+import com.querydsl.core.types.dsl.PathInits;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.core.types.dsl.TimePath;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.core.convert.support.ConfigurableConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.data.convert.Jsr310Converters;
+
+class CollectionFilterQuerydslPredicateConverterTest {
+
+    private static CollectionFiltersMapping createMapping(CollectionFilter filter) {
+        return new CollectionFiltersMapping() {
+
+            @Override
+            public CollectionFilters forDomainType(Class<?> domainType) {
+                return new CollectionFilters() {
+                    @Override
+                    public Stream<CollectionFilter> filters() {
+                        return Stream.of(filter);
+                    }
+                };
+            }
+
+            @Override
+            public Optional<CollectionFilter> forProperty(Class<?> domainType, String... properties) {
+                return Optional.empty();
+            }
+
+            @Override
+            public Optional<CollectionFilter> forIdProperty(Class<?> domainType, String... properties) {
+                return Optional.empty();
+            }
+        };
+    }
+
+
+    @Builder
+    @Getter
+    private static class TestCollectionFilter implements CollectionFilter {
+        private final String filterName;
+        @Builder.Default
+        private final boolean documented = true;
+
+        private final Path<?> path;
+
+        Collection<?> lastParameters;
+
+        @Override
+        public Optional<Predicate> createPredicate(Collection<?> parameters) {
+            lastParameters = parameters;
+            return Optional.empty();
+        }
+    }
+
+    @Value
+    private static class TestObject {
+        String stringValue;
+        Instant timeValue;
+        Boolean booleanValue;
+        int intValue;
+        UUID uuidValue;
+    }
+
+
+    private static class QTestObject extends BeanPath<TestObject> {
+        public QTestObject(String variable) {
+            super(TestObject.class, variable);
+        }
+
+        public QTestObject(Path<?> parent, String property) {
+            super(TestObject.class, parent, property);
+        }
+
+        public QTestObject(PathMetadata metadata) {
+            super(TestObject.class, metadata);
+        }
+
+        public QTestObject(PathMetadata metadata, PathInits inits) {
+            super(TestObject.class, metadata, inits);
+        }
+
+        public final StringPath stringValue = createString("stringValue");
+        public final TimePath<Instant> timeValue = createTime("timeValue", Instant.class);
+        public final BooleanPath booleanValue = createBoolean("booleanValue");
+        public final ComparablePath<UUID> uuidValue = createComparable("uuidValue", UUID.class);
+
+    }
+
+    private static final QTestObject TEST_PATH = new QTestObject("o");
+
+    private static final ConfigurableConversionService conversionService = new DefaultConversionService();
+
+    static {
+        Jsr310Converters.getConvertersToRegister().forEach(conversionService::addConverter);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void typeConversion(Path<?> path, Collection<String> inputValues, Collection<?> outputValues) {
+        var filter = TestCollectionFilter.builder()
+                .filterName("test")
+                .path(path)
+                .build();
+        var converter = new CollectionFilterQuerydslPredicateConverter(
+                createMapping(filter),
+                conversionService
+        );
+
+        converter.getPredicate(TestObject.class, Map.of("test", inputValues));
+
+        assertThat(filter.lastParameters).isEqualTo(outputValues);
+    }
+
+    public static Stream<Arguments> typeConversion() {
+        return Stream.of(
+                Arguments.of(TEST_PATH.stringValue, List.of("abc"), List.of("abc")),
+                Arguments.of(TEST_PATH.booleanValue, List.of("true"), List.of(true)),
+                Arguments.of(TEST_PATH.timeValue, List.of("1994-08-10T22:15:00Z"), List.of(Instant.parse("1994-08-10T22:15:00Z"))),
+                Arguments.of(TEST_PATH.uuidValue, List.of("a1a8f7a8-4283-11ee-852b-8353804234d2"), List.of(UUID.fromString("a1a8f7a8-4283-11ee-852b-8353804234d2")))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void failedTypeConversion(Path<?> path, Collection<String> inputValues) {
+        var filter = TestCollectionFilter.builder()
+                .filterName("test")
+                .path(path)
+                .build();
+        var converter = new CollectionFilterQuerydslPredicateConverter(
+                createMapping(filter),
+                conversionService
+        );
+
+        assertThatThrownBy(() -> converter.getPredicate(TestObject.class, Map.of("test", inputValues)))
+                .isInstanceOfSatisfying(InvalidCollectionFilterValueException.class, exception -> {
+                    assertThat(exception.getFilter()).isEqualTo(filter);
+                    assertThat(exception.getInvalidValue()).isEqualTo(inputValues.iterator().next());
+                });
+    }
+
+    public static Stream<Arguments> failedTypeConversion() {
+        return Stream.of(
+                Arguments.of(TEST_PATH.booleanValue, List.of("ZZZ")),
+                Arguments.of(TEST_PATH.uuidValue, List.of("123")),
+                Arguments.of(TEST_PATH.timeValue, List.of("2022-01-05"))
+        );
+    }
+
+}

--- a/integration-tests/integration-tests-spring/build.gradle
+++ b/integration-tests/integration-tests-spring/build.gradle
@@ -20,6 +20,9 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+	}
 }
 
 dependencies {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,9 @@ plugins {
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
+        maven {
+            url "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
 }
 


### PR DESCRIPTION
Using the CollectionFilter-based filters allow a couple of additional features:
 - Only having to define the filters in one place (no more `QuerydslBinderCustomizer` in repositories)
 - Support multiple query parameters bound to the same `Path`, with different actions (like being able to do greater than/less than queries)
