### PR TITLE
Ensure that curies are present on the collection resource

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProvider.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/ContentGridCurieProvider.java
@@ -77,7 +77,7 @@ class ContentGridCurieProvider implements CurieProvider, CurieProviderBuilder {
 
         if(curie == null) {
             // Not curie -> need to check if it's a registered link relation
-            if(!IanaLinkRelations.isIanaRel(relation)) {
+            if(!IanaLinkRelations.isIanaRel(relation) && !HalLinkRelation.CURIES.isSameAs(rel)) {
                 throw new IllegalArgumentException("Relation '%s' is not an IANA-registered relation".formatted(relation));
             }
             return;

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -15,7 +15,9 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.mapping.LinkCollector;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
 import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.LinkRelationProvider;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 
 @Configuration(proxyBeanMethods = false)
@@ -55,5 +57,12 @@ public class ContentGridSpringDataLinksConfiguration {
     @Bean
     RepresentationModelProcessor<CollectionModel<?>> contentGridSpringDataEmbeddedItemResourceProcessor() {
         return new SpringDataEmbeddedItemResourceProcessor();
+    }
+
+    @Bean
+    RepresentationModelProcessor<CollectionModel<?>> contentGridSpringDataEmbeddedCuriesResourceProcessor(
+            LinkRelationProvider linkRelationProvider, CurieProvider curieProvider
+    ) {
+        return new SpringDataEmbeddedCuriesResourceProcessor(linkRelationProvider, curieProvider);
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedCuriesResourceProcessor.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataEmbeddedCuriesResourceProcessor.java
@@ -1,0 +1,84 @@
+package com.contentgrid.spring.data.rest.links;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.hateoas.server.LinkRelationProvider;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.core.EmbeddedWrapper;
+import org.springframework.hateoas.server.core.EmbeddedWrappers;
+
+/**
+ * Adds curies to embedded resources when spring-data-rest doesn't want to add them
+ * <p>
+ * This processor must run with lowest precedence, so it executes after any other resource processors.
+ */
+@RequiredArgsConstructor
+public class SpringDataEmbeddedCuriesResourceProcessor implements RepresentationModelProcessor<CollectionModel<?>>,
+        Ordered {
+
+    private final LinkRelationProvider linkRelationProvider;
+    private final CurieProvider curieProvider;
+
+    @Override
+    public CollectionModel<?> process(CollectionModel<?> model) {
+        var content = model.getContent();
+
+        var linkCuries = model.getLinks()
+                .stream()
+                .anyMatch(this::isCuriedLink);
+
+        var embeddedCuries = content.stream()
+                .filter(EmbeddedWrapper.class::isInstance)
+                .map(EmbeddedWrapper.class::cast)
+                .anyMatch(this::hasCuriedRelation);
+
+        if(linkCuries || embeddedCuries) {
+            return model;
+        }
+
+        var curies = curieProvider.getCurieInformation(model.getLinks());
+
+        for (Object curie : curies) {
+            model.add((Link) curie);
+        }
+
+        return model;
+    }
+
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    private boolean hasCuriedRelation(EmbeddedWrapper embeddedWrapper) {
+        if(embeddedWrapper.getRel().isPresent()) {
+            return isCuriedRel(embeddedWrapper.getRel().get());
+        }
+        var objectType = embeddedWrapper.getRelTargetType();
+
+        var resourceRel = embeddedWrapper.isCollectionValue()?
+                linkRelationProvider.getCollectionResourceRelFor(objectType):
+                linkRelationProvider.getItemResourceRelFor(objectType);
+
+        return isCuriedRel(resourceRel);
+    }
+
+    private boolean isCuriedLink(Link link) {
+        return isCuriedRel(link.getRel());
+    }
+
+    private boolean isCuriedRel(LinkRelation relation) {
+        return HalLinkRelation.of(relation).isCuried();
+    }
+
+}


### PR DESCRIPTION
Because the _embedded link-rel itself is no longer a curied link,
spring-data-rest no longer adds the curies link-rel to the top level item;
even though resources inside the embedded collection have link relations
that require curies to be resolved.

Solving this for all collections with EmbeddedWrappers by adding curies
in a ResourceProcessor if hitting the case when spring-data-rest does not add
curies.
