### PR TITLE
Call correct delegate method in `AggregateLinkCollector#getLinksForNested()`

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/AggregateLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/AggregateLinkCollector.java
@@ -25,7 +25,7 @@ class AggregateLinkCollector implements LinkCollector {
 
     @Override
     public Links getLinksForNested(Object object, Links existing) {
-        existing = delegate.getLinksFor(object, existing);
+        existing = delegate.getLinksForNested(object, existing);
         for (var collector : collectors) {
             existing = collector.getLinksForNested(object, existing);
         }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/support/Content.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/support/Content.java
@@ -5,12 +5,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import jakarta.persistence.Embeddable;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.content.commons.annotations.ContentId;
 import org.springframework.content.commons.annotations.ContentLength;
 import org.springframework.content.commons.annotations.MimeType;
 import org.springframework.content.commons.annotations.OriginalFileName;
 
 @Embeddable
+@Getter
+@Setter
 public class Content {
 
     @ContentId


### PR DESCRIPTION
Calling the `getLinksFor()` delegate method was not intended, and results in a problem when having `@Embedded` objects, as those have no self link, nor an ID to put in a self link
