### PR TITLE
Support one-to-many redirect with pseudo-inverse relation using a plain Column

### DIFF
--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
@@ -99,9 +99,9 @@ class CollectionFiltersMappingImplTest {
             assertThat(filter.isDocumented()).isFalse();
         });
 
-        assertThat(collectionFiltersMapping.forIdProperty(Order.class, "invoice")).hasValueSatisfying(filter -> {
-            assertThat(filter.getFilterName()).isEqualTo("invoice._id");
-            assertThat(filter.getPath()).isEqualTo(QOrder.order.invoice.id);
+        assertThat(collectionFiltersMapping.forIdProperty(Order.class, "customer")).hasValueSatisfying(filter -> {
+            assertThat(filter.getFilterName()).isEqualTo("customer._id");
+            assertThat(filter.getPath()).isEqualTo(QOrder.order.customer.id);
             assertThat(filter.isDocumented()).isFalse();
         });
 
@@ -115,27 +115,6 @@ class CollectionFiltersMappingImplTest {
             assertThat(filter.getFilterName()).isEqualTo("orders.id");
             assertThat(filter.getPath()).isEqualTo(QInvoice.invoice.orders.any().id);
             assertThat(filter.isDocumented()).isTrue();
-        });
-
-        assertThat(collectionFiltersMapping.forIdProperty(ShippingAddress.class, "order")).isEmpty();
-
-        assertThat(collectionFiltersMapping.forIdProperty(EntityWithRenamedId.class, "order")).hasValueSatisfying(filter -> {
-            assertThat(filter.getFilterName()).isEqualTo("order$id");
-        });
-
-        assertThat(collectionFiltersMapping.forIdProperty(Order.class, "invoice")).hasValueSatisfying(filter -> {
-            assertThat(filter.getFilterName()).isEqualTo("invoice._id");
-            assertThat(filter.getPath()).isEqualTo(QOrder.order.invoice.id);
-        });
-
-        assertThat(collectionFiltersMapping.forIdProperty(Invoice.class, "counterparty")).hasValueSatisfying(filter -> {
-            assertThat(filter.getFilterName()).isEqualTo("counterparty");
-            assertThat(filter.getPath()).isEqualTo(QInvoice.invoice.counterparty.id);
-        });
-
-        assertThat(collectionFiltersMapping.forIdProperty(Invoice.class, "orders")).hasValueSatisfying(filter -> {
-            assertThat(filter.getFilterName()).isEqualTo("orders.id");
-            assertThat(filter.getPath()).isEqualTo(QInvoice.invoice.orders.any().id);
         });
 
         assertThat(collectionFiltersMapping.forIdProperty(ShippingAddress.class, "order")).isEmpty();

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/paths/PathNavigatorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/paths/PathNavigatorTest.java
@@ -6,6 +6,7 @@ import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.test.fixture.invoicing.model.QCustomer;
 import com.contentgrid.spring.test.fixture.invoicing.model.QInvoice;
 import com.contentgrid.spring.test.fixture.invoicing.model.QOrder;
+import com.contentgrid.spring.test.fixture.invoicing.model.QRefund;
 import com.contentgrid.spring.test.fixture.invoicing.model.QShippingAddress;
 import com.querydsl.core.types.dsl.PathInits;
 import jakarta.persistence.Entity;
@@ -21,6 +22,7 @@ class PathNavigatorTest {
     public static final PathNavigator CUSTOMER_NAVIGATOR = new PathNavigator(QCustomer.customer);
     public static final PathNavigator INVOICE_NAVIGATOR = new PathNavigator(QInvoice.invoice);
     public static final PathNavigator ORDER_NAVIGATOR = new PathNavigator(QOrder.order);
+    public static final PathNavigator REFUND_NAVIGATOR = new PathNavigator(QRefund.refund);
 
     @Test
     void navigateToDirectProperty() {
@@ -48,19 +50,17 @@ class PathNavigatorTest {
 
     @Test
     void navigateToDeepProperty() {
-        assertThat(ORDER_NAVIGATOR.get("invoice").get("counterparty").get("content").get("filename").getPath()).isEqualTo(
+        assertThat(REFUND_NAVIGATOR.get("invoice").get("counterparty").get("content").get("filename").getPath()).isEqualTo(
                 // This is so we don't run into a PathInits problem ourselves here when reading the property
-                new QOrder(QOrder.order.getMetadata(), new PathInits("*.*.*")).invoice.counterparty.content.filename
+                new QRefund(QRefund.refund.getMetadata(), new PathInits("*.*.*")).invoice.counterparty.content.filename
         );
 
-        assertThat(new PathNavigator(QShippingAddress.shippingAddress).get("order").get("invoice").get("counterparty").get("content").get("filename").getPath()).isEqualTo(
-                new QShippingAddress(QShippingAddress.shippingAddress.getMetadata(), new PathInits("*.*.*.*"))
-                        .order.invoice.counterparty.content.filename
+        assertThat(INVOICE_NAVIGATOR.get("refund").get("invoice").get("counterparty").get("vat").getPath()).isEqualTo(
+                new QInvoice(QInvoice.invoice.getMetadata(), new PathInits("*.*.*.*")).refund.invoice.counterparty.vat
         );
 
-        assertThat(new PathNavigator(QShippingAddress.shippingAddress).get("order").get("invoice").get("counterparty").get("vat").getPath()).isEqualTo(
-                new QShippingAddress(QShippingAddress.shippingAddress.getMetadata(), new PathInits("*.*.*"))
-                        .order.invoice.counterparty.vat
+        assertThat(INVOICE_NAVIGATOR.get("refund").get("invoice").get("counterparty").get("content").get("filename").getPath()).isEqualTo(
+                new QInvoice(QInvoice.invoice.getMetadata(), new PathInits("*.*.*.*")).refund.invoice.counterparty.content.filename
         );
     }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
@@ -70,11 +70,6 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
                     assertThat(customer.isReadOnly()).isFalse();
                     assertThat(customer.isRequired()).isFalse();
                 },
-                invoice -> {
-                    assertThat(invoice.getName()).isEqualTo("invoice");
-                    assertThat(invoice.isReadOnly()).isFalse();
-                    assertThat(invoice.isRequired()).isFalse();
-                },
                 shippingAddress -> {
                     assertThat(shippingAddress.getName()).isEqualTo("shipping_address");
                     assertThat(shippingAddress.isReadOnly()).isFalse();
@@ -141,12 +136,6 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
                 "customer.content.size",
                 "customer.content.mimetype",
                 "customer.content.filename",
-                "invoice.number",
-                "invoice.paid",
-                "invoice.content.length",
-                /*"invoice.content.length.lt",
-                "invoice.content.length.gt",*/
-                "invoice.orders.id",
                 "shipping_address.zip"
         );
     }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerTest.java
@@ -198,6 +198,18 @@ class HalFormsProfileControllerTest {
                                         }
                                     },
                                     {
+                                        name: "refund",
+                                        type: "url",
+                                        options: {
+                                            valueField: "/_links/self/href",
+                                            minItems: 0,
+                                            maxItems: 1,
+                                            link: {
+                                                href: "http://localhost/refunds"
+                                            }
+                                        }
+                                    },
+                                    {
                                         name: "orders",
                                         type: "url",
                                         options: {

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -501,6 +501,28 @@ class InvoicingApplicationTests {
                         });
                     });
                 }
+
+                @Test
+                void putUriList_shouldReplaceLinksAndReturn_http204_noContent() throws Exception {
+                    var xenit = customers.findByVat(ORG_XENIT_VAT).orElseThrow();
+                    var newOrderId = orders.save(new Order(xenit)).getId();
+                    mockMvc.perform(put("/invoices/{id}/orders", INVOICE_1_ID)
+                            .contentType(RestMediaTypes.TEXT_URI_LIST)
+                            .content(
+                                    """
+                                    /orders/%s
+                                    /orders/%s
+                                    """.formatted(ORDER_1_ID, newOrderId)
+                            )
+                    ).andExpect(status().isNoContent());
+
+                    assertThat(invoices.findById(INVOICE_1_ID)).hasValueSatisfying(invoice -> {
+                        assertThat(invoice.getOrders())
+                                .map(Order::getId)
+                                .containsExactlyInAnyOrder(ORDER_1_ID, newOrderId);
+                    });
+
+                }
             }
 
             @Nested

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -19,7 +19,6 @@ import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
 import com.contentgrid.spring.test.fixture.invoicing.model.Order;
 import com.contentgrid.spring.test.fixture.invoicing.model.PromotionCampaign;
-import com.contentgrid.spring.test.fixture.invoicing.model.QOrder;
 import com.contentgrid.spring.test.fixture.invoicing.model.ShippingAddress;
 import com.contentgrid.spring.test.fixture.invoicing.repository.CustomerRepository;
 import com.contentgrid.spring.test.fixture.invoicing.repository.InvoiceRepository;
@@ -38,7 +37,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.StreamSupport;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -62,7 +60,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultHandler;
 import org.springframework.web.util.UriTemplate;
 import org.springframework.web.util.UriUtils;
 
@@ -800,17 +797,11 @@ class InvoicingApplicationTests {
 
                 @Test
                 void getInvoicesOrders_shouldReturn_http302() throws Exception {
-                    var ordersIterable = orders.findAll(QOrder.order.invoice.number.eq(INVOICE_NUMBER_1));
-                    var result = StreamSupport.stream(ordersIterable.spliterator(), false).toList();
-                    assertThat(result).hasSize(2);
 
-                    var firstOrderId = result.get(0).getId();
-
-                    mockMvc.perform(get("/invoices/{invoice}/orders/{order}", invoiceId(INVOICE_NUMBER_1), firstOrderId)
+                    mockMvc.perform(get("/invoices/{invoice}/orders/{order}", invoiceId(INVOICE_NUMBER_1), ORDER_1_ID)
                                     .accept("application/json"))
                             .andExpect(status().isFound())
-                            .andExpect(header().string(HttpHeaders.LOCATION,
-                                    endsWith("/orders/%s".formatted(firstOrderId))));
+                            .andExpect(headers().location().uri("http://localhost/orders/{id}", ORDER_1_ID));
                 }
             }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -405,6 +405,13 @@ class InvoicingApplicationTests {
                             .andExpect(
                                     headers().location().uri("http://localhost/invoices?counterparty={id}", XENIT_ID));
                 }
+
+                @Test
+                void getOrders_forInvoice_shouldReturn_http302_redirect() throws Exception {
+                    mockMvc.perform(get("/invoices/{id}/orders", INVOICE_1_ID).accept(MediaType.APPLICATION_JSON))
+                            .andExpect(status().isFound())
+                            .andExpect(headers().location().uri("http://localhost/orders?invoice._id={id}", INVOICE_1_ID));
+                }
             }
 
             @Nested

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -7,6 +7,7 @@ import com.contentgrid.spring.querydsl.predicate.None;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.OneToOne;
 import java.util.HashSet;
 import java.util.Set;
@@ -90,7 +91,8 @@ public class Invoice {
     @CollectionFilterParam(predicate = EntityId.class, documented = false)
     private Customer counterparty;
 
-    @OneToMany(mappedBy = "invoice")
+    @OneToMany
+    @JoinColumn(name = "__invoice_id__orders", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"invoice\") references \"invoice\" ON DELETE set NULL"))
     @CollectionFilterParam
     @CollectionFilterParam(value = "orders.id", predicate = EntityId.class)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:orders")
@@ -112,7 +114,7 @@ public class Invoice {
 
         this.orders = orders;
         if (orders != null) {
-            orders.forEach(order -> order.setInvoice(this));
+            orders.forEach(order -> order.set__internal_invoice_id(this.id));
         }
     }
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -7,6 +7,7 @@ import com.contentgrid.spring.querydsl.predicate.None;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.OneToOne;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -94,6 +95,10 @@ public class Invoice {
     @CollectionFilterParam(value = "orders.id", predicate = EntityId.class)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:orders")
     private Set<Order> orders = new HashSet<>();
+
+    @OneToOne(mappedBy = "invoice")
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:refund")
+    private Refund refund;
 
     public Invoice(String number, boolean draft, boolean paid, Customer counterparty, Set<Order> orders) {
         this.number = number;

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
@@ -2,13 +2,14 @@ package com.contentgrid.spring.test.fixture.invoicing.model;
 
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.Column;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import jakarta.persistence.Entity;
-import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -40,11 +41,10 @@ public class Order {
     @RestResource(rel = "d:customer")
     private Customer customer;
 
-    @ManyToOne
-    @JoinColumn(name = "invoice", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"invoice\") references \"invoice\" ON DELETE set NULL"))
-    @CollectionFilterParam(value = "invoice._id", predicate = EntityId.class, documented = false)
-    @RestResource(exported = false)
-    private Invoice invoice;
+    @Column(name = "__invoice_id__orders", insertable = false, updatable = false)
+    @CollectionFilterParam(value = "invoice._id", documented = false)
+    @JsonIgnore
+    private UUID __internal_invoice_id;
 
     @ManyToMany
     @RestResource(rel = "d:promos")

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
@@ -42,9 +42,8 @@ public class Order {
 
     @ManyToOne
     @JoinColumn(name = "invoice", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"invoice\") references \"invoice\" ON DELETE set NULL"))
-    @CollectionFilterParam
     @CollectionFilterParam(value = "invoice._id", predicate = EntityId.class, documented = false)
-    @RestResource(rel = "d:invoice")
+    @RestResource(exported = false)
     private Invoice invoice;
 
     @ManyToMany


### PR DESCRIPTION
To support permissions on -to-many relations, we have a feature in to automatically redirect to collection of the target of the relation, with a collection filter applied.
For example: `/invoices/$id/orders` becomes `/orders?invoice._id=$id`

To be able to apply a collection filter on the target domain type, that type needs a reference to the source domain type. (so, a bi-directional relation)
We don’t want to implement full user-configurable bi-directional relations for now, since that requires additional considerations.

The complications of bi-directional relations in JPA:
- The inverse side of a relation is read-only: Hibernate does not look at the inverse side of the relation when saving changes
- The `@ManyToOne` relation annotation does not have a `mappedBy` attribute, so in a bi-directional relation it is always the primary side; `@OneToMany` will always be the inverse side in a bi-directional relation. Uni-directional `@OneToMany` is fine and there it can be the primary side.

If we limit the scope of bi-directional relations to the ones required to support permissions on relations:
- `@ManyToOne`: No problem, we redirect directly to the “one” item on the target side, we don’t need filters
- `@OneToOne`: No problem, identical to `@ManyToOne`
- `@ManyToMany`: No problem, the side on the target entity can be the inverse side. We mark it as not exported, so it’s not visible in the API response, and it’s not writable
- `@OneToMany`: Ouch, according to our model we need a `@ManyToOne` on the inverse side, but from the perspective of JPA, that needs to be the primary side. That would mean that API users can’t write to the relation anymore from the primary side of the model (and the other side is not visible in the API)

To solve this problem, we need to keep the `@OneToMany` side the JPA primary side. Technically, the data is stored in the table of the target. We point there with a `@JoinColumn` annotation.

Since technically the data is already present on the table of the target entity, we should be able to access it from that side as well, but we can’t make it a `@ManyToOne` relation. Since it is stored in the table of the entity, a plain `@Column` annotation enables us to pull the data in.
It is a bit of a wonky setup, but if we take care to only read data from there, and don’t rely on it being updated within the same JPA session, it should be fine.
Since writing and reading data always happens from separate HTTP requests, we can be sure that they are separate sessions and we don’t need to worry about this.

