### PR TITLE
Add HAL-FORMS templates for modifying relations

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
@@ -69,7 +69,17 @@ class SpringDataAssociationLinkCollector implements ContentGridLinkCollector {
     }
 
     private Link addAssociationAffordance(Link associationLink, Class<?> owner, Property association) {
-        if (!association.getTypeInformation().isCollectionLike()) {
+        if(association.getTypeInformation().isMap()) {
+            // Map types are not really supported yet, so they don't get any affordances
+            return associationLink;
+        } if (association.getTypeInformation().isCollectionLike()) {
+            return Affordances.of(associationLink)
+                    .afford(HttpMethod.POST)
+                    .withName("add-" + associationLink.getName())
+                    .withInput(createPayloadMetadataForRelation(owner, association))
+                    .withInputMediaType(RestMediaTypes.TEXT_URI_LIST)
+                    .toLink();
+        } else {
             var affordances = Affordances.of(associationLink);
             affordances = affordances.afford(HttpMethod.PUT)
                     .withName("set-" + associationLink.getName())
@@ -83,13 +93,6 @@ class SpringDataAssociationLinkCollector implements ContentGridLinkCollector {
                         .build();
             }
             return affordances.toLink();
-        } else {
-            return Affordances.of(associationLink)
-                    .afford(HttpMethod.POST)
-                    .withName("add-" + associationLink.getName())
-                    .withInput(createPayloadMetadataForRelation(owner, association))
-                    .withInputMediaType(RestMediaTypes.TEXT_URI_LIST)
-                    .toLink();
         }
     }
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollector.java
@@ -1,17 +1,30 @@
 package com.contentgrid.spring.data.rest.links;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.contentgrid.spring.data.rest.mapping.Property;
+import com.contentgrid.spring.data.rest.mapping.jackson.JacksonBasedProperty;
+import com.contentgrid.spring.data.rest.mapping.persistent.PersistentPropertyProperty;
+import com.contentgrid.spring.data.rest.mapping.rest.DataRestBasedProperty;
 import java.util.ArrayList;
-import java.util.Objects;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.core.ResolvableType;
 import org.springframework.data.mapping.SimpleAssociationHandler;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.rest.core.Path;
 import org.springframework.data.rest.core.support.SelfLinkProvider;
+import org.springframework.data.rest.webmvc.RestMediaTypes;
 import org.springframework.data.rest.webmvc.mapping.Associations;
+import org.springframework.hateoas.AffordanceModel.PayloadMetadata;
+import org.springframework.hateoas.AffordanceModel.PropertyMetadata;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Links;
+import org.springframework.hateoas.mediatype.Affordances;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.hateoas.mediatype.html.HtmlInputType;
+import org.springframework.http.HttpMethod;
 
 /**
  * Collects links to jpa relations in the {@link ContentGridLinkRelations#RELATION} link-relation
@@ -37,15 +50,13 @@ class SpringDataAssociationLinkCollector implements ContentGridLinkCollector {
 
         entities.getRequiredPersistentEntity(object.getClass()).doWithAssociations(
                 (SimpleAssociationHandler) association -> {
-                    if(!associationLinks.isLinkableAssociation(association)) {
-                        return;
-                    }
-
-                    var property = association.getInverse();
-                    var linkName = readLinkName(property);
-
+                    // We create a property here, so the name matches the one generated for the HAL-FORMS configuration
+                    // That will automatically create the HAL-FORMS options for the property
+                    var property = new JacksonBasedProperty(new DataRestBasedProperty(new PersistentPropertyProperty(association.getInverse())));
                     for (Link link : associationLinks.getLinksFor(association, selfPath)) {
-                        links.add(link.withRel(ContentGridLinkRelations.RELATION).withName(linkName));
+                        var linkName = HalLinkRelation.of(link.getRel()).getLocalPart();
+                        var cgRelLink = link.withRel(ContentGridLinkRelations.RELATION).withName(linkName);
+                        links.add(addAssociationAffordance(cgRelLink, object.getClass(), property));
                     }
                 });
 
@@ -57,12 +68,79 @@ class SpringDataAssociationLinkCollector implements ContentGridLinkCollector {
         return existing;
     }
 
-    private String readLinkName(PersistentProperty<?> property) {
-        var jsonProperty = property.findAnnotation(JsonProperty.class);
-        if(jsonProperty != null && !Objects.equals(jsonProperty.value(), JsonProperty.USE_DEFAULT_NAME)) {
-            return jsonProperty.value();
+    private Link addAssociationAffordance(Link associationLink, Class<?> owner, Property association) {
+        if (!association.getTypeInformation().isCollectionLike()) {
+            return Affordances.of(associationLink)
+                    .afford(HttpMethod.PUT)
+                    .withName("set-" + associationLink.getName())
+                    .withInput(createPayloadMetadataForRelation(owner, association))
+                    .withInputMediaType(RestMediaTypes.TEXT_URI_LIST)
+                    .andAfford(HttpMethod.DELETE)
+                    .withName("clear-" + associationLink.getName())
+                    .toLink();
+        } else {
+            return Affordances.of(associationLink)
+                    .afford(HttpMethod.POST)
+                    .withName("add-" + associationLink.getName())
+                    .withInput(createPayloadMetadataForRelation(owner, association))
+                    .withInputMediaType(RestMediaTypes.TEXT_URI_LIST)
+                    .toLink();
         }
-        return property.getName();
     }
 
+    private PayloadMetadata createPayloadMetadataForRelation(Class<?> owner, Property association) {
+        return new AssociationPayloadMetadata(owner, List.of(
+                new AssociationPropertyMetadata(association)
+        ));
+    }
+
+    @RequiredArgsConstructor
+    private static class AssociationPayloadMetadata implements PayloadMetadata {
+
+        @Getter
+        private final Class<?> type;
+        private final List<PropertyMetadata> properties;
+
+
+        @Override
+        public Stream<PropertyMetadata> stream() {
+            return properties.stream();
+        }
+    }
+
+    @RequiredArgsConstructor
+    private static class AssociationPropertyMetadata implements PropertyMetadata {
+
+        private final Property association;
+
+        @Override
+        public String getName() {
+            return association.getName();
+        }
+
+        @Override
+        public boolean isRequired() {
+            return association.isRequired();
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return association.isReadOnly();
+        }
+
+        @Override
+        public Optional<String> getPattern() {
+            return Optional.empty();
+        }
+
+        @Override
+        public ResolvableType getType() {
+            return association.getTypeInformation().toTypeDescriptor().getResolvableType();
+        }
+
+        @Override
+        public String getInputType() {
+            return HtmlInputType.URL_VALUE;
+        }
+    }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -84,7 +84,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                             }
                         }
                         """.formatted(customer.getId())))
-                .andExpect(MockMvcResultMatchers.jsonPath("$._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$._templates.keys()", Matchers.containsInAnyOrder("default", "delete", "add-invoices", "add-orders")));
     }
 
     @Test
@@ -137,7 +137,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                 // No top-level _templates are present
                 .andExpect(MockMvcResultMatchers.jsonPath("$.keys()", Matchers.not(Matchers.contains("_templates"))))
                 // The templates of the embedded object only contain a default and a delete template
-                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.['item'][0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete")));
+                .andExpect(MockMvcResultMatchers.jsonPath("$._embedded.['item'][0]._templates.keys()", Matchers.containsInAnyOrder("default", "delete", "add-invoices", "add-orders")));
         ;
     }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollectorTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/SpringDataAssociationLinkCollectorTest.java
@@ -9,7 +9,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.rest.webmvc.RestMediaTypes;
+import org.springframework.hateoas.AffordanceModel;
+import org.springframework.hateoas.AffordanceModel.InputPayloadMetadata;
 import org.springframework.hateoas.Links;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.html.HtmlInputType;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.context.ContextConfiguration;
 
 @SpringBootTest
@@ -29,9 +35,30 @@ class SpringDataAssociationLinkCollectorTest {
                 .allSatisfy(link -> {
                     assertThat(link.getRel()).isEqualTo(ContentGridLinkRelations.RELATION);
                 })
-                .satisfiesExactlyInAnyOrder(link -> {
+                .satisfiesExactly(link -> {
                     assertThat(link.getName()).isEqualTo("order");
                     assertThat(link.getHref()).isEqualTo("http://localhost/shipping-addresses/%s/order".formatted(entity.getId()));
+
+                    assertThat(link.getAffordances()).<AffordanceModel>map(affordance -> affordance.getAffordanceModel(MediaTypes.HAL_FORMS_JSON))
+                            .satisfiesExactlyInAnyOrder(
+                                    setOrderAffordance -> {
+                                        assertThat(setOrderAffordance.getName()).isEqualTo("set-order");
+                                        assertThat(setOrderAffordance.getHttpMethod()).isEqualTo(HttpMethod.PUT);
+                                        assertThat(setOrderAffordance.getLink().getHref()).isEqualTo(link.getHref());
+                                        assertThat(setOrderAffordance.getInput().getPrimaryMediaType()).isEqualTo(RestMediaTypes.TEXT_URI_LIST);
+                                        assertThat(setOrderAffordance.getInput().getType()).isEqualTo(ShippingAddress.class);
+                                        assertThat(setOrderAffordance.getInput().stream()).satisfiesExactly(orderRelation -> {
+                                            assertThat(orderRelation.getName()).isEqualTo("order");
+                                            assertThat(orderRelation.getInputType()).isEqualTo(HtmlInputType.URL_VALUE);
+                                        });
+                                    },
+                                    clearOrderAffordance -> {
+                                        assertThat(clearOrderAffordance.getName()).isEqualTo("clear-order");
+                                        assertThat(clearOrderAffordance.getHttpMethod()).isEqualTo(HttpMethod.DELETE);
+                                        assertThat(clearOrderAffordance.getLink().getHref()).isEqualTo(link.getHref());
+                                        assertThat(clearOrderAffordance.getInput()).isEqualTo(InputPayloadMetadata.NONE);
+                                    }
+                            );
                 });
     }
 
@@ -48,10 +75,40 @@ class SpringDataAssociationLinkCollectorTest {
                         link -> {
                             assertThat(link.getName()).isEqualTo("orders");
                             assertThat(link.getHref()).isEqualTo("http://localhost/customers/%s/orders".formatted(entity.getId()));
+
+                            assertThat(link.getAffordances()).<AffordanceModel>map(affordance -> affordance.getAffordanceModel(MediaTypes.HAL_FORMS_JSON))
+                                    .satisfiesExactly(
+                                            addOrdersAffordance -> {
+                                                assertThat(addOrdersAffordance.getName()).isEqualTo("add-orders");
+                                                assertThat(addOrdersAffordance.getHttpMethod()).isEqualTo(HttpMethod.POST);
+                                                assertThat(addOrdersAffordance.getLink().getHref()).isEqualTo(link.getHref());
+                                                assertThat(addOrdersAffordance.getInput().getPrimaryMediaType()).isEqualTo(RestMediaTypes.TEXT_URI_LIST);
+                                                assertThat(addOrdersAffordance.getInput().getType()).isEqualTo(Customer.class);
+                                                assertThat(addOrdersAffordance.getInput().stream()).satisfiesExactly(orderRelation -> {
+                                                    assertThat(orderRelation.getName()).isEqualTo("orders");
+                                                    assertThat(orderRelation.getInputType()).isEqualTo(HtmlInputType.URL_VALUE);
+                                                });
+                                            }
+                                    );
                         },
                         link -> {
                             assertThat(link.getName()).isEqualTo("invoices");
                             assertThat(link.getHref()).isEqualTo("http://localhost/customers/%s/invoices".formatted(entity.getId()));
+
+                            assertThat(link.getAffordances()).<AffordanceModel>map(affordance -> affordance.getAffordanceModel(MediaTypes.HAL_FORMS_JSON))
+                                    .satisfiesExactly(
+                                            addInvoicesAffordance -> {
+                                                assertThat(addInvoicesAffordance.getName()).isEqualTo("add-invoices");
+                                                assertThat(addInvoicesAffordance.getHttpMethod()).isEqualTo(HttpMethod.POST);
+                                                assertThat(addInvoicesAffordance.getLink().getHref()).isEqualTo(link.getHref());
+                                                assertThat(addInvoicesAffordance.getInput().getPrimaryMediaType()).isEqualTo(RestMediaTypes.TEXT_URI_LIST);
+                                                assertThat(addInvoicesAffordance.getInput().getType()).isEqualTo(Customer.class);
+                                                assertThat(addInvoicesAffordance.getInput().stream()).satisfiesExactly(orderRelation -> {
+                                                    assertThat(orderRelation.getName()).isEqualTo("invoices");
+                                                    assertThat(orderRelation.getInputType()).isEqualTo(HtmlInputType.URL_VALUE);
+                                                });
+                                            }
+                                    );
                         }
                 );
     }


### PR DESCRIPTION
- For to-one relations, the hal-forms templates on the entity allow both to set a relation and to clear a relation
- For to-many relations, we can only add a template to add items to a relation, as removing items from a relation must happen on a per-item basis

For now we leave adding a template to remove an item for a to-many relation out of scope.
