### PR TITLE
Fix database isolation in tests

### DIFF
--- a/contentgrid-spring-data-rest/build.gradle
+++ b/contentgrid-spring-data-rest/build.gradle
@@ -46,13 +46,16 @@ dependencies {
 
     testFixturesImplementation platform(project(':contentgrid-spring-boot-platform'))
     testFixturesImplementation project(':contentgrid-spring-boot-starter')
+    testFixturesImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     testFixturesApi 'org.springframework.data:spring-data-jpa'
 
     testFixturesCompileOnly 'org.projectlombok:lombok'
+    testFixturesImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testFixturesImplementation 'org.testcontainers:postgresql:1.19.0'
+
 
     testFixturesRuntimeOnly 'org.postgresql:postgresql'
-    testFixturesRuntimeOnly 'org.testcontainers:postgresql:1.19.0'
 }
 
 tasks.named('test') {

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplication.java
@@ -3,9 +3,10 @@ package com.contentgrid.spring.test.fixture.invoicing;
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
-import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 @SpringBootApplication
 public class InvoicingApplication {
@@ -17,6 +18,15 @@ public class InvoicingApplication {
     @Bean
     CurieProviderCustomizer datamodelCurieProviderCustomizer() {
         return CurieProviderCustomizer.register("d", "https://contentgrid.com/rels/datamodel/{rel}");
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestDatabaseConfiguration {
+        @Bean
+        @ServiceConnection
+        PostgreSQLContainer postgreSQLContainer() {
+            return new PostgreSQLContainer();
+        }
     }
 
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -92,7 +92,7 @@ public class Invoice {
     private Customer counterparty;
 
     @OneToMany
-    @JoinColumn(name = "__invoice_id__orders", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"invoice\") references \"invoice\" ON DELETE set NULL"))
+    @JoinColumn(name = "__invoice_id__orders", foreignKey = @ForeignKey(foreignKeyDefinition = "foreign key (\"__invoice_id__orders\") references \"invoice\" ON DELETE set NULL"))
     @CollectionFilterParam
     @CollectionFilterParam(value = "orders.id", predicate = EntityId.class)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:orders")

--- a/contentgrid-spring-data-rest/src/testFixtures/resources/application.yml
+++ b/contentgrid-spring-data-rest/src/testFixtures/resources/application.yml
@@ -1,6 +1,4 @@
 spring:
-  datasource:
-    url: jdbc:tc:postgresql:14:///
   jpa:
     show-sql: true
     hibernate:

--- a/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/EntityChangeHibernateEventListenerTest.java
+++ b/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/EntityChangeHibernateEventListenerTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.support.TransactionTemplate;
 
 @SpringBootTest(classes = {InvoicingApplication.class, TestConfig.class})
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
 class EntityChangeHibernateEventListenerTest {
     @Autowired
     CustomerRepository customerRepository;
@@ -107,7 +107,7 @@ class EntityChangeHibernateEventListenerTest {
     void whenCustomerIsUpdatedOnce_postUpdateShouldBeCalledOnce_ok() {
 
         Customer customer1 = new Customer();
-        customer1.setVat("BE123");
+        customer1.setVat("BE124");
         customer1.setName("old name");
 
         Customer saved = customerRepository.save(customer1);
@@ -122,7 +122,7 @@ class EntityChangeHibernateEventListenerTest {
 
     @Test
     void whenCustomerIsUpdatedTwice_postUpdateShouldBeCalledTwice_ok() {
-        Customer saved = customerRepository.save(customer(c -> c.setVat("BE123")));
+        Customer saved = customerRepository.save(customer(c -> c.setVat("BE125")));
         saved.setName("description for update");
         customerRepository.save(saved);
 
@@ -138,7 +138,7 @@ class EntityChangeHibernateEventListenerTest {
 
     @Test
     void whenCustomerIsDeleted_postUpdateShouldBeCalledOnce_ok() {
-        Customer saved = customerRepository.save(customer(c -> c.setVat("BE123")));
+        Customer saved = customerRepository.save(customer(c -> c.setVat("BE126")));
 
         saved.setName("description for update");
         customerRepository.save(saved);
@@ -179,7 +179,7 @@ class EntityChangeHibernateEventListenerTest {
     @Test
     void whenCustomerIsAddedToOrderCustomer_manyToOne_postUpdateShouldBeCalledOnce_ok() {
         Order order = orderRepository.save(new Order());
-        Customer customer = customerRepository.save(customer(c -> c.setVat("BE123")));
+        Customer customer = customerRepository.save(customer(c -> c.setVat("BE127")));
 
         order.setCustomer(customer);
         orderRepository.save(order);
@@ -197,7 +197,7 @@ class EntityChangeHibernateEventListenerTest {
         // events are sent after committing the tx. If we don't run it in a transaction, hibernate complains about
         // a lack of an open session when we try to do anything with case.hasEvidence.
         transactionTemplate.executeWithoutResult((status) -> {
-            var customer = customerRepository.save(customer(c -> c.setVat("BE123")));
+            var customer = customerRepository.save(customer(c -> c.setVat("BE128")));
             UUID invoiceId = invoiceRepository.save(invoice(i -> {
                 i.setCounterparty(customer);
                 i.setNumber("X888");


### PR DESCRIPTION
It turns out that the jdbc-based testcontainers has a problem where all
connections that use the same jdbc url are shared to the same database
instance. This causes a problem when tests run in parallel, as hibernate
sets up and destroys the schema on every application context start, but
it's all on the same database.

Using the spring `@ServiceConnection` instead ensures that a different
database is started for every time the application context is
(re)created, avoiding any problems with a shared database