### PR TITLE
Use RFC7807 problem details for reporting errors

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -5,6 +5,7 @@ import com.contentgrid.spring.data.rest.hal.ContentGridCurieConfiguration;
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
 import com.contentgrid.spring.data.rest.links.ContentGridSpringContentRestLinksConfiguration;
 import com.contentgrid.spring.data.rest.links.ContentGridSpringDataLinksConfiguration;
+import com.contentgrid.spring.data.rest.problem.ContentGridProblemDetailsConfiguration;
 import com.contentgrid.spring.data.rest.validation.ContentGridSpringDataRestValidationConfiguration;
 import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -28,7 +29,8 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
         ContentGridSpringDataRestConfiguration.class,
         ContentGridSpringDataRestProfileConfiguration.class,
         ContentGridSpringDataRestAffordancesConfiguration.class,
-        ContentGridSpringDataRestValidationConfiguration.class
+        ContentGridSpringDataRestValidationConfiguration.class,
+        ContentGridProblemDetailsConfiguration.class
 })
 @AutoConfigureAfter(
         name = {

--- a/contentgrid-spring-data-rest/build.gradle
+++ b/contentgrid-spring-data-rest/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'com.querydsl:querydsl-core'
     implementation 'jakarta.persistence:jakarta.persistence-api'
     implementation 'jakarta.servlet:jakarta.servlet-api'
+    implementation 'jakarta.validation:jakarta.validation-api'
 
     implementation 'org.springframework.data:spring-data-rest-webmvc'
     implementation 'com.github.paulcwarren:spring-content-rest'
@@ -41,6 +42,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'jakarta.transaction:jakarta.transaction-api'
+    testImplementation project(':contentgrid-spring-boot-autoconfigure')
 
     testFixturesAnnotationProcessor project(':contentgrid-spring-boot-starter-annotations')
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/ContentGridDomainTypeMappingConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/ContentGridDomainTypeMappingConfiguration.java
@@ -15,9 +15,15 @@ import org.springframework.data.repository.support.Repositories;
 @Import(ContentGridCollectionFilterMappingConfiguration.class)
 public class ContentGridDomainTypeMappingConfiguration {
     @Bean
+    @PlainMapping
+    DomainTypeMapping plainDomainTypeMapping(Repositories repositories) {
+        return new DomainTypeMapping(repositories);
+    }
+
+    @Bean
     @FormMapping
-    DomainTypeMapping halFormsFormMappingDomainTypeMapping(Repositories repositories) {
-        return new DomainTypeMapping(repositories, c -> new JacksonBasedContainer(new DataRestBasedContainer(c)));
+    DomainTypeMapping halFormsFormMappingDomainTypeMapping(@PlainMapping DomainTypeMapping plainMapping) {
+        return plainMapping.wrapWith(c -> new JacksonBasedContainer(new DataRestBasedContainer(c)));
     }
 
     @Bean

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/ContentGridDomainTypeMappingConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/ContentGridDomainTypeMappingConfiguration.java
@@ -2,6 +2,7 @@ package com.contentgrid.spring.data.rest.mapping;
 
 import com.contentgrid.spring.data.querydsl.mapping.ContentGridCollectionFilterMappingConfiguration;
 import com.contentgrid.spring.data.rest.mapping.jackson.JacksonBasedContainer;
+import com.contentgrid.spring.data.rest.mapping.persistent.ThroughAssociationsContainer;
 import com.contentgrid.spring.data.rest.mapping.rest.DataRestBasedContainer;
 import com.contentgrid.spring.data.rest.webmvc.DefaultDomainTypeToHalFormsPayloadMetadataConverter;
 import com.contentgrid.spring.data.rest.webmvc.DomainTypeToHalFormsPayloadMetadataConverter;
@@ -18,6 +19,12 @@ public class ContentGridDomainTypeMappingConfiguration {
     @PlainMapping
     DomainTypeMapping plainDomainTypeMapping(Repositories repositories) {
         return new DomainTypeMapping(repositories);
+    }
+
+    @Bean
+    @PlainMapping(followingAssociations = true)
+    DomainTypeMapping plainDomainTypeMappingFollowingAssociations(@PlainMapping DomainTypeMapping domainTypeMapping, Repositories repositories) {
+        return domainTypeMapping.wrapWith(c -> new ThroughAssociationsContainer(c, repositories, Integer.MAX_VALUE));
     }
 
     @Bean

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/PlainMapping.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/PlainMapping.java
@@ -17,5 +17,5 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @Documented
 @Qualifier
 public @interface PlainMapping {
-
+    boolean followingAssociations() default false;
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/PlainMapping.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/mapping/PlainMapping.java
@@ -9,13 +9,13 @@ import java.lang.annotation.Target;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Qualifier annotation for {@link DomainTypeMapping} that relates to search query parameters
+ * Qualifier annotation for {@link DomainTypeMapping} that relates to a plain mapping that does not change property names
  */
 @Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Documented
 @Qualifier
-public @interface SearchMapping {
+public @interface PlainMapping {
 
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridExceptionHandler.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridExceptionHandler.java
@@ -1,0 +1,126 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import com.contentgrid.spring.data.rest.problem.ext.ConstraintViolationProblemProperties;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import jakarta.validation.ConstraintViolation;
+import java.util.Objects;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.data.rest.core.RepositoryConstraintViolationException;
+import org.springframework.hateoas.mediatype.problem.Problem;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+@ResponseBody
+@RequiredArgsConstructor
+public class ContentGridExceptionHandler {
+
+    @NonNull
+    private final ProblemTypeUrlFactory problemTypeUrlFactory;
+
+    @NonNull
+    private final MessageSourceAccessor messageSourceAccessor;
+
+    @NonNull
+    private final JsonPropertyPathConverter jsonPropertyPathConverter;
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    Problem handleConstraintViolation(ConstraintViolationException exception) {
+        return Problem.create()
+                .withStatus(HttpStatus.CONFLICT)
+                .withType(problemTypeUrlFactory.resolve(ProblemType.CONSTRAINT_VIOLATION))
+                .withTitle(messageSourceAccessor.getMessage(
+                        ProblemType.CONSTRAINT_VIOLATION.withArguments(exception.getConstraintName())))
+                .withDetail(exception.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleRepositoryConstraintViolationException(RepositoryConstraintViolationException ex) {
+        var problem = Problem.create()
+                .withType(problemTypeUrlFactory.resolve(ProblemType.VALIDATION_CONSTRAINT_VIOLATION))
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withTitle(messageSourceAccessor.getMessage(ProblemType.VALIDATION_CONSTRAINT_VIOLATION));
+
+        if (ex.getErrors() instanceof BindingResult bindingResult) {
+            var domainType = bindingResult.getTarget().getClass();
+            var propertiesBuilder = ConstraintViolationProblemProperties.builder();
+
+            bindingResult.getGlobalErrors().forEach(error -> {
+                propertiesBuilder.global(null, messageSourceAccessor.getMessage(error));
+            });
+
+            bindingResult.getFieldErrors().forEach(error -> {
+                propertiesBuilder.field(
+                        null,
+                        jsonPropertyPathConverter.fromJavaPropertyPath(domainType, error.getField()),
+                        messageSourceAccessor.getMessage(error),
+                        error.getRejectedValue()
+                );
+            });
+
+            return problem.withProperties(propertiesBuilder.build());
+        }
+
+        return problem;
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleMismatchedInput(MismatchedInputException exception) {
+        return Problem.create()
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withType(problemTypeUrlFactory.resolve(ProblemType.VALIDATION_CONSTRAINT_VIOLATION))
+                .withTitle(messageSourceAccessor.getMessage(ProblemType.VALIDATION_CONSTRAINT_VIOLATION))
+                .withProperties(
+                        ConstraintViolationProblemProperties.builder()
+                                .global(
+                                        problemTypeUrlFactory.resolve(ProblemType.INVALID_REQUEST_BODY_TYPE),
+                                        messageSourceAccessor.getMessage(ProblemType.INVALID_REQUEST_BODY_TYPE)
+                                )
+                                .build()
+                );
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleJsonParseException(JsonParseException exception) {
+        return Problem.create()
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withType(problemTypeUrlFactory.resolve(ProblemType.INVALID_REQUEST_BODY_JSON))
+                .withTitle(messageSourceAccessor.getMessage(ProblemType.INVALID_REQUEST_BODY_JSON))
+                .withDetail(formatJacksonError(exception));
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleNotReadable(HttpMessageNotReadableException exception) {
+        return Problem.create()
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withType(problemTypeUrlFactory.resolve(ProblemType.INVALID_REQUEST_BODY))
+                .withTitle(messageSourceAccessor.getMessage(ProblemType.INVALID_REQUEST_BODY))
+                .withDetail(exception.getMessage());
+    }
+
+    private static String formatJacksonError(JsonProcessingException exception) {
+        var message = Objects.requireNonNullElse(exception.getOriginalMessage(), "No message");
+        var location = exception.getLocation();
+        if (location == null) {
+            return message;
+        }
+
+        return message + " at " + location.offsetDescription();
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -28,7 +28,7 @@ public class ContentGridProblemDetailsConfiguration {
 
     @Bean
     ProblemTypeUrlFactory contentGridProblemTypeUrlFactory() {
-        return new ProblemTypeUrlFactory(UriTemplate.of("https://contentgrid.com/rels/problem{/item*}"));
+        return new ProblemTypeUrlFactory(UriTemplate.of("https://contentgrid.cloud/problems{/item*}"));
     }
 
     @Bean

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -37,18 +37,18 @@ public class ContentGridProblemDetailsConfiguration {
     }
 
     @Bean
-    @Order(-1)
-    ContentGridExceptionHandler contentGridExceptionHandler(ProblemTypeUrlFactory problemTypeUrlFactory,
-            JsonPropertyPathConverter jsonPropertyPathConverter) {
-        var problemTypeMessageSource = new ResourceBundleMessageSource();
-        problemTypeMessageSource.setBasename("com.contentgrid.spring.data.rest.problem.messages");
+    ProblemFactory problemFactory(ProblemTypeUrlFactory problemTypeUrlFactory) {
+        return new ProblemFactory(ProblemTypeMessageSource.getAccessor(), problemTypeUrlFactory);
+    }
 
+    @Bean
+    @Order(-1)
+    ContentGridExceptionHandler contentGridExceptionHandler(
+            ProblemFactory problemFactory,
+            JsonPropertyPathConverter jsonPropertyPathConverter) {
         return new ContentGridExceptionHandler(
-                problemTypeUrlFactory,
-                new MessageSourceAccessor(new DelegatingMessageSource(
-                        applicationContext,
-                        problemTypeMessageSource
-                )),
+                problemFactory,
+                new MessageSourceAccessor(applicationContext),
                 jsonPropertyPathConverter
         );
     }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -1,9 +1,21 @@
 package com.contentgrid.spring.data.rest.problem;
 
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import com.contentgrid.spring.data.rest.mapping.PlainMapping;
+import java.util.Locale;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.MessageSource;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.NoSuchMessageException;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.context.support.MessageSourceSupport;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.annotation.Order;
+import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
 
@@ -11,6 +23,35 @@ import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType
 @RequiredArgsConstructor
 @EnableHypermediaSupport(type = HypermediaType.HTTP_PROBLEM_DETAILS)
 public class ContentGridProblemDetailsConfiguration {
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    ProblemTypeUrlFactory contentGridProblemTypeUrlFactory() {
+        return new ProblemTypeUrlFactory(UriTemplate.of("https://contentgrid.com/rels/problem{/item*}"));
+    }
+
+    @Bean
+    JsonPropertyPathConverter jsonPropertyPathConverter(@PlainMapping DomainTypeMapping domainTypeMapping) {
+        return new JsonPropertyPathConverter(domainTypeMapping);
+    }
+
+    @Bean
+    @Order(-1)
+    ContentGridExceptionHandler contentGridExceptionHandler(ProblemTypeUrlFactory problemTypeUrlFactory,
+            JsonPropertyPathConverter jsonPropertyPathConverter) {
+        var problemTypeMessageSource = new ResourceBundleMessageSource();
+        problemTypeMessageSource.setBasename("com.contentgrid.spring.data.rest.problem.messages");
+
+        return new ContentGridExceptionHandler(
+                problemTypeUrlFactory,
+                new MessageSourceAccessor(new DelegatingMessageSource(
+                        applicationContext,
+                        problemTypeMessageSource
+                )),
+                jsonPropertyPathConverter
+        );
+    }
 
     @Bean
     @Order(0)
@@ -24,5 +65,42 @@ public class ContentGridProblemDetailsConfiguration {
         return new SpringContentRestExceptionHandler();
     }
 
+    @RequiredArgsConstructor
+    private static class DelegatingMessageSource extends MessageSourceSupport implements MessageSource {
+
+        private final MessageSource primary;
+        private final MessageSource fallback;
+
+        @Override
+        public String getMessage(@NonNull String code, Object[] args, String defaultMessage, @NonNull Locale locale) {
+            var message = primary.getMessage(code, args, null, locale);
+            if (message != null) {
+                return message;
+            }
+            return fallback.getMessage(code, args, defaultMessage, locale);
+        }
+
+        @Override
+        @NonNull
+        public String getMessage(@NonNull String code, Object[] args, @NonNull Locale locale)
+                throws NoSuchMessageException {
+            try {
+                return primary.getMessage(code, args, locale);
+            } catch (NoSuchMessageException ex) {
+                return fallback.getMessage(code, args, locale);
+            }
+        }
+
+        @Override
+        @NonNull
+        public String getMessage(@NonNull MessageSourceResolvable resolvable, @NonNull Locale locale)
+                throws NoSuchMessageException {
+            try {
+                return primary.getMessage(resolvable, locale);
+            } catch (NoSuchMessageException ex) {
+                return fallback.getMessage(resolvable, locale);
+            }
+        }
+    }
 
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -1,0 +1,28 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.hateoas.config.EnableHypermediaSupport;
+import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
+
+@Configuration(proxyBeanMethods = false)
+@RequiredArgsConstructor
+@EnableHypermediaSupport(type = HypermediaType.HTTP_PROBLEM_DETAILS)
+public class ContentGridProblemDetailsConfiguration {
+
+    @Bean
+    @Order(0)
+    SpringDataRestRepositoryExceptionHandler contentGridSpringDataRestRepositoryExceptionHandler() {
+        return new SpringDataRestRepositoryExceptionHandler();
+    }
+
+    @Bean
+    @Order(0)
+    SpringContentRestExceptionHandler contentGridSpringContentRestRepositoryExceptionHandler() {
+        return new SpringContentRestExceptionHandler();
+    }
+
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -37,7 +37,12 @@ public class ContentGridProblemDetailsConfiguration {
     }
 
     @Bean
-    ProblemFactory problemFactory(ProblemTypeUrlFactory problemTypeUrlFactory) {
+    ResponseEntityFactory contentGridProblemResponseEntityFactory() {
+        return new ResponseEntityFactory();
+    }
+
+    @Bean
+    ProblemFactory contentGridProblemFactory(ProblemTypeUrlFactory problemTypeUrlFactory) {
         return new ProblemFactory(ProblemTypeMessageSource.getAccessor(), problemTypeUrlFactory);
     }
 
@@ -45,24 +50,27 @@ public class ContentGridProblemDetailsConfiguration {
     @Order(-1)
     ContentGridExceptionHandler contentGridExceptionHandler(
             ProblemFactory problemFactory,
-            JsonPropertyPathConverter jsonPropertyPathConverter) {
+            JsonPropertyPathConverter jsonPropertyPathConverter,
+            ResponseEntityFactory responseEntityFactory
+    ) {
         return new ContentGridExceptionHandler(
                 problemFactory,
                 new MessageSourceAccessor(applicationContext),
-                jsonPropertyPathConverter
+                jsonPropertyPathConverter,
+                responseEntityFactory
         );
     }
 
     @Bean
     @Order(0)
-    SpringDataRestRepositoryExceptionHandler contentGridSpringDataRestRepositoryExceptionHandler() {
-        return new SpringDataRestRepositoryExceptionHandler();
+    SpringDataRestRepositoryExceptionHandler contentGridSpringDataRestRepositoryExceptionHandler(ResponseEntityFactory responseEntityFactory) {
+        return new SpringDataRestRepositoryExceptionHandler(responseEntityFactory);
     }
 
     @Bean
     @Order(0)
-    SpringContentRestExceptionHandler contentGridSpringContentRestRepositoryExceptionHandler() {
-        return new SpringContentRestExceptionHandler();
+    SpringContentRestExceptionHandler contentGridSpringContentRestRepositoryExceptionHandler(ResponseEntityFactory responseEntityFactory) {
+        return new SpringContentRestExceptionHandler(responseEntityFactory);
     }
 
     @RequiredArgsConstructor

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/JsonPropertyPathConverter.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/JsonPropertyPathConverter.java
@@ -1,0 +1,93 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import com.contentgrid.spring.data.rest.mapping.Container;
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import com.contentgrid.spring.data.rest.mapping.Property;
+import com.contentgrid.spring.data.rest.mapping.jackson.JacksonBasedProperty;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JsonPropertyPathConverter {
+
+    private final DomainTypeMapping domainTypeMapping;
+    private final Map<CacheKey, String> fromJavaPropertyPathCache = new ConcurrentHashMap<>();
+
+    public String fromJavaPropertyPath(Class<?> domainType, String javaPropertyPath) {
+        return fromJavaPropertyPathCache.computeIfAbsent(
+                new CacheKey(domainType, javaPropertyPath),
+                this::createFromJavaPropertyPath
+        );
+    }
+
+    private String createFromJavaPropertyPath(CacheKey key) {
+        return convertPropertyPath(
+                domainTypeMapping.forDomainType(key.domainType()),
+                key.propertyPath().split("\\.")
+        )
+                .map(JacksonBasedProperty::new)
+                // If any property in the chain is ignored, it doesn't have a name
+                .map(prop -> prop.isIgnored() ? null : prop.getName())
+                .reduce("", (a, b) -> {
+                    // If there is any ignored property in the chain, we refuse to create a property path
+                    if (a == null || b == null) {
+                        return null;
+                    }
+                    if (a.isEmpty()) {
+                        return b;
+                    } else if (b.isEmpty()) {
+                        return a;
+                    } else {
+                        return a + "." + b;
+                    }
+                });
+    }
+
+    private Stream<Property> convertPropertyPath(Container topContainer, String[] propertyPath) {
+        Optional<Container> maybeContainer = Optional.of(topContainer);
+        Stream.Builder<Property> properties = Stream.builder();
+
+        for (String propertyName : propertyPath) {
+            var container = maybeContainer.orElseThrow(
+                    () -> createPropertyPathException(propertyPath, properties, "no container"));
+            var property = findProperty(container, propertyName);
+            if (property == null) {
+                throw createPropertyPathException(propertyPath, properties, "property not found");
+            }
+            properties.add(property);
+            maybeContainer = property.nestedContainer();
+        }
+
+        return properties.build();
+    }
+
+    private Property findProperty(Container container, String propertyName) {
+        AtomicReference<Property> found = new AtomicReference<>();
+        container.doWithAll(property -> {
+            if (Objects.equals(property.getName(), propertyName)) {
+                found.set(property);
+            }
+        });
+
+        return found.get();
+    }
+
+    private IllegalStateException createPropertyPathException(String[] propertyPath, Stream.Builder<Property> builder,
+            String msg) {
+        return new IllegalStateException("Can not expand property path '%s' at position %d: %s".formatted(
+                String.join(".", propertyPath),
+                builder.build().count(),
+                msg
+        ));
+    }
+
+    private record CacheKey(Class<?> domainType, String propertyPath) {
+
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemFactory.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemFactory.java
@@ -1,0 +1,28 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.hateoas.mediatype.problem.Problem;
+
+@RequiredArgsConstructor
+public class ProblemFactory {
+    private final MessageSourceAccessor messageSourceAccessor;
+    private final ProblemTypeUrlFactory problemTypeUrlFactory;
+
+    public Problem createProblem(ProblemType problemType, Object ...arguments) {
+        return Problem.create()
+                .withType(problemTypeUrlFactory.resolve(problemType))
+                .withTitle(resolveMessage(problemType.forTitle()))
+                .withDetail(resolveMessage(problemType.forDetails(arguments)));
+    }
+
+    private String resolveMessage(MessageSourceResolvable resolvable) {
+        var message = messageSourceAccessor.getMessage(resolvable);
+        if(message.isEmpty()) {
+            return null;
+        }
+        return message;
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
@@ -8,7 +8,7 @@ import org.springframework.context.MessageSourceResolvable;
 public enum ProblemType implements ProblemTypeResolvable {
     VALIDATION_CONSTRAINT_VIOLATION("integrity", "validation-constraint-violation"),
     CONSTRAINT_VIOLATION("integrity", "constraint-violation"),
-    UNIQUE_CONSTRAINT_VIOLATION("integrity", "constraint-violation", "unique"),
+    DUPLICATE_VALUE("integrity", "constraint-violation", "duplicate-value"),
 
     INVALID_REQUEST_BODY("invalid-request-body"),
     INVALID_REQUEST_BODY_TYPE("invalid-request-body", "type"),

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
@@ -1,0 +1,66 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import com.contentgrid.spring.data.rest.problem.ProblemTypeUrlFactory.ProblemTypeResolvable;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSourceResolvable;
+
+public enum ProblemType implements MessageSourceResolvable, ProblemTypeResolvable {
+    VALIDATION_CONSTRAINT_VIOLATION("integrity", "validation-constraint-violation"),
+    CONSTRAINT_VIOLATION("integrity", "constraint-violation"),
+    UNIQUE_CONSTRAINT_VIOLATION("integrity", "constraint-violation", "unique"),
+
+    INVALID_REQUEST_BODY("invalid-request-body"),
+    INVALID_REQUEST_BODY_TYPE("invalid-request-body", "type"),
+    INVALID_REQUEST_BODY_JSON("invalid-request-body", "json");
+
+    ProblemType(String... params) {
+        this.params = params;
+    }
+
+    private final static String CLASSNAME = ProblemType.class.getName();
+
+    final String[] params;
+    private String[] codes = null;
+
+    @Override
+    public String[] getProblemHierarchy() {
+        return params;
+    }
+
+    @Override
+    public String[] getCodes() {
+        if (this.codes == null) {
+            var paramsList = Arrays.asList(params);
+            var codes = new String[this.params.length];
+
+            for (int i = codes.length; i > 0; i--) {
+                codes[codes.length - i] = CLASSNAME + "." + String.join(".", paramsList.subList(0, i));
+            }
+            this.codes = codes;
+            return codes;
+        }
+        return this.codes;
+    }
+
+    public MessageSourceResolvable withArguments(Object... arguments) {
+        return new DelegatingMessageSourceResolvableWithArguments(this, arguments);
+    }
+
+    @RequiredArgsConstructor
+    private static class DelegatingMessageSourceResolvableWithArguments implements MessageSourceResolvable {
+
+        private final MessageSourceResolvable resolvable;
+        private final Object[] arguments;
+
+        @Override
+        public String[] getCodes() {
+            return resolvable.getCodes();
+        }
+
+        @Override
+        public Object[] getArguments() {
+            return arguments;
+        }
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemTypeMessageSource.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemTypeMessageSource.java
@@ -1,0 +1,14 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.context.support.ResourceBundleMessageSource;
+
+public final class ProblemTypeMessageSource extends ResourceBundleMessageSource {
+    private ProblemTypeMessageSource() {
+        setBasename("com.contentgrid.spring.data.rest.problem.messages");
+    }
+
+    public static MessageSourceAccessor getAccessor() {
+        return new MessageSourceAccessor(new ProblemTypeMessageSource());
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemTypeUrlFactory.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemTypeUrlFactory.java
@@ -1,0 +1,22 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import java.net.URI;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.UriTemplate;
+
+@RequiredArgsConstructor
+class ProblemTypeUrlFactory {
+
+    private final UriTemplate baseUri;
+
+    public URI resolve(ProblemTypeResolvable type) {
+        return baseUri.expand(List.of(type.getProblemHierarchy()));
+    }
+
+    public interface ProblemTypeResolvable {
+
+        String[] getProblemHierarchy();
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ResponseEntityFactory.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ResponseEntityFactory.java
@@ -1,0 +1,18 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import org.springframework.hateoas.mediatype.problem.Problem;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseEntityFactory {
+    public ResponseEntity<Problem> createResponse(Problem problem) {
+        var responseBuilder = ResponseEntity.internalServerError();
+        if(problem.getStatus() != null) {
+            responseBuilder = ResponseEntity.status(problem.getStatus());
+        }
+
+        return responseBuilder.contentType(MediaType.APPLICATION_PROBLEM_JSON)
+                .body(problem);
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringContentRestExceptionHandler.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringContentRestExceptionHandler.java
@@ -8,26 +8,27 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.hateoas.mediatype.problem.Problem;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.versions.LockOwnerException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ControllerAdvice(basePackageClasses = StoreRestExceptionHandler.class)
-@ResponseBody
 @RequiredArgsConstructor
 public class SpringContentRestExceptionHandler {
+    private final ResponseEntityFactory responseEntityFactory;
+
     @ExceptionHandler({ LockOwnerException.class,
             OptimisticLockException.class,
             OptimisticLockingFailureException.class,
             PessimisticLockException.class,
             PessimisticLockingFailureException.class})
-    @ResponseStatus(HttpStatus.CONFLICT)
-    Problem handleConflict(Exception e) {
-        return Problem.create()
+    ResponseEntity<Problem> handleConflict(Exception e) {
+        return responseEntityFactory.createResponse(
+                Problem.create()
                 .withStatus(HttpStatus.CONFLICT)
-                .withTitle(e.getMessage());
+                .withTitle(e.getMessage())
+        );
     }
 
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringContentRestExceptionHandler.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringContentRestExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import internal.org.springframework.content.rest.controllers.StoreRestExceptionHandler;
+import jakarta.persistence.OptimisticLockException;
+import jakarta.persistence.PessimisticLockException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.hateoas.mediatype.problem.Problem;
+import org.springframework.http.HttpStatus;
+import org.springframework.versions.LockOwnerException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice(basePackageClasses = StoreRestExceptionHandler.class)
+@ResponseBody
+@RequiredArgsConstructor
+public class SpringContentRestExceptionHandler {
+    @ExceptionHandler({ LockOwnerException.class,
+            OptimisticLockException.class,
+            OptimisticLockingFailureException.class,
+            PessimisticLockException.class,
+            PessimisticLockingFailureException.class})
+    @ResponseStatus(HttpStatus.CONFLICT)
+    Problem handleConflict(Exception e) {
+        return Problem.create()
+                .withStatus(HttpStatus.CONFLICT)
+                .withTitle(e.getMessage());
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringDataRestRepositoryExceptionHandler.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringDataRestRepositoryExceptionHandler.java
@@ -1,9 +1,7 @@
 package com.contentgrid.spring.data.rest.problem;
 
 import java.lang.reflect.InvocationTargetException;
-import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -12,59 +10,62 @@ import org.springframework.data.rest.webmvc.RepositoryRestExceptionHandler;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.hateoas.mediatype.problem.Problem;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
 
 /**
  * Overwrite the default spring-data-rest exception handlers to use problem details
  * @see RepositoryRestExceptionHandler
  */
 @ControllerAdvice(basePackageClasses = RepositoryRestExceptionHandler.class)
-@ResponseBody
 @RequiredArgsConstructor
 public class SpringDataRestRepositoryExceptionHandler {
 
+    private final ResponseEntityFactory responseEntityFactory;
+
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.NOT_FOUND)
-    Problem handleNotFound(ResourceNotFoundException ex) {
-        return Problem.create()
-                .withStatus(HttpStatus.NOT_FOUND);
+    ResponseEntity<Problem> handleNotFound(ResourceNotFoundException ex) {
+        return responseEntityFactory.createResponse(Problem.create()
+                .withStatus(HttpStatus.NOT_FOUND));
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    Problem handleNotReadable(HttpMessageNotReadableException ex) {
-        return Problem.create()
-                .withStatus(HttpStatus.BAD_REQUEST)
-                .withTitle(ex.getMessage());
+    ResponseEntity<Problem> handleNotReadable(HttpMessageNotReadableException ex) {
+        return responseEntityFactory.createResponse(
+                Problem.create()
+                        .withStatus(HttpStatus.BAD_REQUEST)
+                        .withTitle(ex.getMessage())
+        );
     }
 
     @ExceptionHandler({ InvocationTargetException.class, IllegalArgumentException.class, ClassCastException.class,
             ConversionFailedException.class, NullPointerException.class })
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    Problem handleMiscFailures(Exception ex) {
-        return Problem.create()
+    ResponseEntity<Problem> handleMiscFailures(Exception ex) {
+        return responseEntityFactory.createResponse(
+                Problem.create()
                 .withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-                .withTitle(ex.getMessage());
+                .withTitle(ex.getMessage())
+        );
     }
 
     @ExceptionHandler
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    Problem handleRepositoryConstraintViolationException(RepositoryConstraintViolationException ex) {
-        return Problem.create()
-                .withStatus(HttpStatus.BAD_REQUEST)
-                .withTitle(ex.getMessage());
+    ResponseEntity<Problem> handleRepositoryConstraintViolationException(RepositoryConstraintViolationException ex) {
+        return responseEntityFactory.createResponse(
+                Problem.create()
+                        .withStatus(HttpStatus.BAD_REQUEST)
+                        .withTitle(ex.getMessage())
+        );
     }
 
     @ExceptionHandler({ OptimisticLockingFailureException.class, DataIntegrityViolationException.class })
-    @ResponseStatus(HttpStatus.CONFLICT)
-    Problem handleConflict(Exception ex) {
-        return Problem.create()
-                .withStatus(HttpStatus.CONFLICT)
-                .withTitle(ex.getMessage());
+    ResponseEntity<Problem> handleConflict(Exception ex) {
+        return responseEntityFactory.createResponse(
+                Problem.create()
+                        .withStatus(HttpStatus.CONFLICT)
+                        .withTitle(ex.getMessage())
+        );
     }
 
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringDataRestRepositoryExceptionHandler.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/SpringDataRestRepositoryExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import java.lang.reflect.InvocationTargetException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.rest.core.RepositoryConstraintViolationException;
+import org.springframework.data.rest.webmvc.RepositoryRestExceptionHandler;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.hateoas.mediatype.problem.Problem;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Overwrite the default spring-data-rest exception handlers to use problem details
+ * @see RepositoryRestExceptionHandler
+ */
+@ControllerAdvice(basePackageClasses = RepositoryRestExceptionHandler.class)
+@ResponseBody
+@RequiredArgsConstructor
+public class SpringDataRestRepositoryExceptionHandler {
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    Problem handleNotFound(ResourceNotFoundException ex) {
+        return Problem.create()
+                .withStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleNotReadable(HttpMessageNotReadableException ex) {
+        return Problem.create()
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withTitle(ex.getMessage());
+    }
+
+    @ExceptionHandler({ InvocationTargetException.class, IllegalArgumentException.class, ClassCastException.class,
+            ConversionFailedException.class, NullPointerException.class })
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    Problem handleMiscFailures(Exception ex) {
+        return Problem.create()
+                .withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                .withTitle(ex.getMessage());
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Problem handleRepositoryConstraintViolationException(RepositoryConstraintViolationException ex) {
+        return Problem.create()
+                .withStatus(HttpStatus.BAD_REQUEST)
+                .withTitle(ex.getMessage());
+    }
+
+    @ExceptionHandler({ OptimisticLockingFailureException.class, DataIntegrityViolationException.class })
+    @ResponseStatus(HttpStatus.CONFLICT)
+    Problem handleConflict(Exception ex) {
+        return Problem.create()
+                .withStatus(HttpStatus.CONFLICT)
+                .withTitle(ex.getMessage());
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/ConstraintViolationProblemProperties.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/ConstraintViolationProblemProperties.java
@@ -1,13 +1,10 @@
 package com.contentgrid.spring.data.rest.problem.ext;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.net.URI;
 import java.util.List;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Singular;
 import lombok.Value;
-import lombok.experimental.NonFinal;
 import org.springframework.hateoas.mediatype.problem.Problem;
 
 /**
@@ -25,46 +22,37 @@ public class ConstraintViolationProblemProperties {
 
     public static class ConstraintViolationProblemPropertiesBuilder {
 
-        public ConstraintViolationProblemPropertiesBuilder global(URI type, String message) {
-            return error(Problem.create()
-                    .withType(type)
-                    .withTitle(message)
+        public ConstraintViolationProblemPropertiesBuilder global(Problem problem) {
+            return error(problem);
+        }
+
+        public ConstraintViolationProblemPropertiesBuilder field(Problem problem, String fieldName) {
+            return error(
+                    MergedProblemProperties.extend(
+                            problem,
+                            new FieldViolationProblemProperties(fieldName)
+                    )
             );
         }
 
-        public ConstraintViolationProblemPropertiesBuilder field(URI type, String message, String property) {
-            return error(Problem.create()
-                    .withType(type)
-                    .withTitle(message)
-                    .withProperties(new FieldViolationProblemProperties(property))
-            );
-        }
-
-        public ConstraintViolationProblemPropertiesBuilder field(URI type, String message, String property,
-                Object invalidValue) {
-            return error(Problem.create()
-                    .withType(type)
-                    .withTitle(message)
-                    .withProperties(new InvalidValueFieldViolationProblemProperties(property, invalidValue))
+        public ConstraintViolationProblemPropertiesBuilder field(Problem problem, String fieldName, Object invalidValue) {
+            return error(MergedProblemProperties.extend(
+                            problem,
+                            new FieldViolationProblemProperties(fieldName),
+                            new InvalidValueProblemProperties(invalidValue)
+                    )
             );
         }
     }
 
     @Value
-    @NonFinal
-    private static class FieldViolationProblemProperties {
+    public static class FieldViolationProblemProperties {
 
         String property;
     }
 
     @Value
-    @EqualsAndHashCode(callSuper = true)
-    private static class InvalidValueFieldViolationProblemProperties extends FieldViolationProblemProperties {
-
-        public InvalidValueFieldViolationProblemProperties(String property, Object invalidValue) {
-            super(property);
-            this.invalidValue = invalidValue;
-        }
+    private static class InvalidValueProblemProperties {
 
         @JsonProperty("invalid_value")
         Object invalidValue;

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/ConstraintViolationProblemProperties.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/ConstraintViolationProblemProperties.java
@@ -1,0 +1,72 @@
+package com.contentgrid.spring.data.rest.problem.ext;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
+import java.util.List;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Singular;
+import lombok.Value;
+import lombok.experimental.NonFinal;
+import org.springframework.hateoas.mediatype.problem.Problem;
+
+/**
+ * API representation for a constraint violation problem details
+ * <p>
+ * This is part of the public API of the application, don't make backwards incompatible changes
+ */
+@Value
+@Builder
+public class ConstraintViolationProblemProperties {
+
+    @Singular
+    @JsonProperty("errors")
+    List<Problem> errors;
+
+    public static class ConstraintViolationProblemPropertiesBuilder {
+
+        public ConstraintViolationProblemPropertiesBuilder global(URI type, String message) {
+            return error(Problem.create()
+                    .withType(type)
+                    .withTitle(message)
+            );
+        }
+
+        public ConstraintViolationProblemPropertiesBuilder field(URI type, String message, String property) {
+            return error(Problem.create()
+                    .withType(type)
+                    .withTitle(message)
+                    .withProperties(new FieldViolationProblemProperties(property))
+            );
+        }
+
+        public ConstraintViolationProblemPropertiesBuilder field(URI type, String message, String property,
+                Object invalidValue) {
+            return error(Problem.create()
+                    .withType(type)
+                    .withTitle(message)
+                    .withProperties(new InvalidValueFieldViolationProblemProperties(property, invalidValue))
+            );
+        }
+    }
+
+    @Value
+    @NonFinal
+    private static class FieldViolationProblemProperties {
+
+        String property;
+    }
+
+    @Value
+    @EqualsAndHashCode(callSuper = true)
+    private static class InvalidValueFieldViolationProblemProperties extends FieldViolationProblemProperties {
+
+        public InvalidValueFieldViolationProblemProperties(String property, Object invalidValue) {
+            super(property);
+            this.invalidValue = invalidValue;
+        }
+
+        @JsonProperty("invalid_value")
+        Object invalidValue;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/MergedProblemProperties.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ext/MergedProblemProperties.java
@@ -1,0 +1,67 @@
+package com.contentgrid.spring.data.rest.problem.ext;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.mediatype.problem.Problem;
+import org.springframework.hateoas.mediatype.problem.Problem.ExtendedProblem;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MergedProblemProperties {
+    @JsonUnwrapped
+    @JsonInclude(Include.NON_NULL)
+    private final Object original;
+
+    @JsonUnwrapped
+    private final Object extension;
+
+    public static Problem extend(Problem problem, Object... extensions) {
+        var properties = create(problem);
+        for (Object extension : extensions) {
+            properties = properties.extendedWith(extension);
+        }
+        return problem.withProperties(properties);
+    }
+
+    public static Problem extend(Problem problem, UnaryOperator<MergedProblemProperties> customizer) {
+        var properties = create(problem);
+        var updatedProperties = customizer.apply(properties);
+        if(properties == updatedProperties) {
+            return problem;
+        }
+        return problem.withProperties(updatedProperties);
+    }
+
+    public static MergedProblemProperties create(Problem problem) {
+        if(problem instanceof ExtendedProblem<?> extendedProblem) {
+            return new MergedProblemProperties(extendedProblem.getProperties(), null);
+        } else {
+            return new MergedProblemProperties(null, null);
+        }
+    }
+
+    public MergedProblemProperties extendedWith(Object extension) {
+        if(extension == null) {
+            return new MergedProblemProperties(original, extension);
+        } else {
+            return new MergedProblemProperties(this, extension);
+        }
+    }
+
+    public <T> Optional<T> findExtension(Class<T> type) {
+        if(type.isInstance(extension)) {
+            return Optional.of((T)extension);
+        } else if(type.isInstance(original)) {
+            return Optional.of((T) original);
+        } else if(original instanceof MergedProblemProperties mergedProblemProperties) {
+            return mergedProblemProperties.findExtension(type);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
@@ -1,0 +1,8 @@
+com.contentgrid.spring.data.rest.problem.ProblemType.integrity=Invalid input
+com.contentgrid.spring.data.rest.problem.ProblemType.integrity.validation-constraint-violation=Validation error
+com.contentgrid.spring.data.rest.problem.ProblemType.integrity.constraint-violation=Rejected by database constraint ''{0}''
+com.contentgrid.spring.data.rest.problem.ProblemType.integrity.constraint-violation.unique=Unique constraint ''{0}'': value is not unique
+
+com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body=Request body is invalid
+com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body.json=Request body is invalid JSON
+com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body.type=Invalid datatype

--- a/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
@@ -1,8 +1,14 @@
-com.contentgrid.spring.data.rest.problem.ProblemType.integrity=Invalid input
-com.contentgrid.spring.data.rest.problem.ProblemType.integrity.validation-constraint-violation=Validation error
-com.contentgrid.spring.data.rest.problem.ProblemType.integrity.constraint-violation=Rejected by database constraint ''{0}''
-com.contentgrid.spring.data.rest.problem.ProblemType.integrity.constraint-violation.unique=Unique constraint ''{0}'': value is not unique
+com.contentgrid.spring.data.rest.problem.ProblemType.title.integrity=Invalid input
+com.contentgrid.spring.data.rest.problem.ProblemType.detail.integrity=
 
-com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body=Request body is invalid
-com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body.json=Request body is invalid JSON
-com.contentgrid.spring.data.rest.problem.ProblemType.invalid-request-body.type=Invalid datatype
+com.contentgrid.spring.data.rest.problem.ProblemType.title.integrity.validation-constraint-violation=Validation error
+com.contentgrid.spring.data.rest.problem.ProblemType.detail.integrity.validation-constraint-violation={0} validation errors
+
+com.contentgrid.spring.data.rest.problem.ProblemType.title.integrity.constraint-violation=Rejected by database constraint
+com.contentgrid.spring.data.rest.problem.ProblemType.detail.integrity.constraint-violation=Database constraint ''{0}'' rejected store
+com.contentgrid.spring.data.rest.problem.ProblemType.title.integrity.constraint-violation.unique=Value is not unique
+
+com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-request-body=Request body is invalid
+com.contentgrid.spring.data.rest.problem.ProblemType.detail.invalid-request-body=
+com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-request-body.json=Request body is invalid JSON
+com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-request-body.type=Request body uses an invalid datatype for a property

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -142,10 +142,8 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                                     }
                                     """)
                     )
-                    .andExpect(validationConstraintViolation()
-                            .withError(error -> error.withProperty("total_spend")
-                                    .withType(PROBLEM_TYPE_PREFIX + "invalid-request-body/type")
-                            )
+                    .andExpect(problemDetails()
+                            .withType(PROBLEM_TYPE_PREFIX+"invalid-request-body/type")
                     );
 
         }
@@ -162,10 +160,8 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                                     }
                                     """)
                     )
-                    .andExpect(validationConstraintViolation()
-                            .withError(error -> error.withProperty("content")
-                                    .withType(PROBLEM_TYPE_PREFIX + "invalid-request-body/type")
-                            )
+                    .andExpect(problemDetails()
+                            .withType(PROBLEM_TYPE_PREFIX+"invalid-request-body/type")
                     );
         }
 
@@ -181,10 +177,8 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                                     }
                                     """)
                     )
-                    .andExpect(validationConstraintViolation()
-                            .withError(error -> error.withProperty("birthday")
-                                    .withType(PROBLEM_TYPE_PREFIX + "invalid-request-body/type")
-                            )
+                    .andExpect(problemDetails()
+                            .withType(PROBLEM_TYPE_PREFIX+"invalid-request-body/type")
                     );
         }
 
@@ -200,10 +194,9 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                                     }
                                     """)
                     )
-                    .andExpect(validationConstraintViolation()
-                            .withError(error -> error.withProperty("counterparty")
-                            )
-                    )
+                    .andExpect(problemDetails()
+                            .withType(PROBLEM_TYPE_PREFIX+"invalid-request-body/type")
+                    );
             ;
         }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -120,6 +121,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void doesNotParseAsJson(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     { "my-invalid-json }
                                     """)
@@ -135,6 +137,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void typeMismatchStringToNumber(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "123",
@@ -153,6 +156,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void typeMismatchStringToObject(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "456",
@@ -170,6 +174,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void typeMismatchStringDoesNotParseToDate(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "789",
@@ -187,6 +192,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void toOneRelationInvalidUrl(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "number": "123",
@@ -205,6 +211,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void toOneRelationDifferentEntityUrl(HttpMethod method, String url) throws Exception {
             mockMvc.perform(request(method, url)
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "number": "123",
@@ -259,6 +266,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             var customer = createCustomer();
             mockMvc.perform(post("/invoices")
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "counterparty": "/customers/%s"
@@ -274,6 +282,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
         void createEntityWithoutRequiredRelation() throws Exception {
             mockMvc.perform(post("/invoices")
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "number": "%s"
@@ -291,6 +300,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             var customer = createCustomer();
             mockMvc.perform(put("/invoices/{id}", invoice.getId())
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "counterparty": "/customers/%s"
@@ -303,6 +313,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
 
             mockMvc.perform(patch("/invoices/{id}", invoice.getId())
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "number": null
@@ -332,6 +343,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             var invoice = createInvoice();
             mockMvc.perform(patch("/invoices/{id}", invoice.getId())
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "counterparty": null
@@ -424,6 +436,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // First time goes through
             mockMvc.perform(post("/customers")
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "%s"
@@ -435,6 +448,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // Second time results in a unique constraint error
             mockMvc.perform(post("/customers")
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "%s"
@@ -455,6 +469,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // Create goes through
             mockMvc.perform(post("/customers")
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "%s"
@@ -466,6 +481,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // Update to same id fails
             mockMvc.perform(patch("/customers/{id}", customer.getId())
                             .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
                             .content("""
                                     {
                                         "vat": "%s"

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -52,7 +52,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
     private static final String CUSTOMER_ID_CREATE = "bd5ef028-52fb-11ee-a531-b3ff1a44e992";
     private static final String INVOICE_ID_CREATE = "bd5ef028-52fb-11ee-a531-b3ff1a44e993";
 
-    private static final String PROBLEM_TYPE_PREFIX = "https://contentgrid.com/rels/problem/";
+    private static final String PROBLEM_TYPE_PREFIX = "https://contentgrid.cloud/problems/";
 
     @Autowired
     MockMvc mockMvc;

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -1,0 +1,443 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+
+import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
+import com.contentgrid.spring.test.fixture.invoicing.model.Refund;
+import com.contentgrid.spring.test.fixture.invoicing.repository.CustomerRepository;
+import com.contentgrid.spring.test.fixture.invoicing.repository.InvoiceRepository;
+import com.contentgrid.spring.test.fixture.invoicing.repository.RefundRepository;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+/**
+ * All cases to be covered - Invalid json (no domain object can be constructed) - Validator violations (domain object
+ * constructed; required attribute/relation missing) - Deletion violations (on delete object is still referenced by
+ * required relation) - Database constraint errors (non-validation covered constraints)
+ */
+@SpringBootTest(classes = InvoicingApplication.class)
+@EnableAutoConfiguration(exclude = EventsAutoConfiguration.class)
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+@DirtiesContext(classMode = ClassMode.AFTER_CLASS)
+class ContentGridProblemDetailsConfigurationIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    public static final String CUSTOMER_ID_CREATE = "bd5ef028-52fb-11ee-a531-b3ff1a44e992";
+    public static final String INVOICE_ID_CREATE = "bd5ef028-52fb-11ee-a531-b3ff1a44e993";
+
+    @Autowired
+    CustomerRepository customerRepository;
+
+    @Autowired
+    InvoiceRepository invoiceRepository;
+
+    private Customer createCustomer() {
+        var customer = new Customer();
+        customer.setVat("vat-" + UUID.randomUUID());
+        return customerRepository.save(customer);
+    }
+
+    private Invoice createInvoice() {
+        var invoice = new Invoice();
+        invoice.setNumber("invoice-" + UUID.randomUUID());
+        invoice.setCounterparty(createCustomer());
+        return invoiceRepository.save(invoice);
+    }
+
+    @AfterEach
+    void cleanup(@Autowired CustomerRepository customerRepository, @Autowired InvoiceRepository invoiceRepository) {
+        invoiceRepository.deleteById(UUID.fromString(INVOICE_ID_CREATE));
+        customerRepository.deleteById(UUID.fromString(CUSTOMER_ID_CREATE));
+    }
+
+    /**
+     * Tests all invalid json input cases:
+     *
+     * <ul>
+     * <li>Does not parse as json
+     * <li>Type mismatch: trying to use a string for a number
+     * <li>Type mismatch: trying to use a string for an object
+     * <li>Type mismatch: string does not parse to a date
+     * <li>to-one relation input: not a valid URL
+     * <li>to-one relation input: URL to a different entity
+     * </ul>
+     */
+    @Nested
+    class InvalidJson {
+
+        public static String CUSTOMER_ID_UPDATE;
+        public static String INVOICE_ID_UPDATE;
+
+        @BeforeAll
+        static void setup(@Autowired CustomerRepository customerRepository,
+                @Autowired InvoiceRepository invoiceRepository) {
+            var customer = new Customer();
+            customer.setVat("vat-" + UUID.randomUUID());
+            customer = customerRepository.save(customer);
+            CUSTOMER_ID_UPDATE = customer.getId().toString();
+
+            var invoice = new Invoice();
+            invoice.setNumber("invoice-" + UUID.randomUUID());
+            invoice.setCounterparty(customer);
+            invoice = invoiceRepository.save(invoice);
+            INVOICE_ID_UPDATE = invoice.getId().toString();
+        }
+
+        @ParameterizedTest
+        @MethodSource({"basicUrls"})
+        void doesNotParseAsJson(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    { "my-invalid-json }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @MethodSource({"basicUrls"})
+        void typeMismatchStringToNumber(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "123",
+                                        "total_spend": "none yet"
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+        }
+
+        @ParameterizedTest
+        @MethodSource({"basicUrls"})
+        void typeMismatchStringToObject(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "456",
+                                        "content": "XYZ"
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @MethodSource({"basicUrls"})
+        void typeMismatchStringDoesNotParseToDate(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "789",
+                                        "birthday": "2022-01-01"
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @MethodSource("relationUrls")
+        void toOneRelationInvalidUrl(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "1123",
+                                        "counterparty": "ZZEY"
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @ParameterizedTest
+        @MethodSource("relationUrls")
+        void toOneRelationDifferentEntityUrl(HttpMethod method, String url) throws Exception {
+            mockMvc.perform(request(method, url)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "1124",
+                                        "counterparty": "/invoices/%s"
+                                    }
+                                    """.formatted(INVOICE_ID_UPDATE))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        static Stream<Arguments> basicUrls() {
+            return Stream.of(
+                    Arguments.of(HttpMethod.POST, "/customers"),
+                    Arguments.of(HttpMethod.PUT, "/customers/" + CUSTOMER_ID_CREATE),
+                    Arguments.of(HttpMethod.PUT, "/customers/" + CUSTOMER_ID_UPDATE),
+                    Arguments.of(HttpMethod.PATCH, "/customers/" + CUSTOMER_ID_UPDATE)
+            );
+        }
+
+        static Stream<Arguments> relationUrls() {
+            return Stream.of(
+                    Arguments.of(HttpMethod.POST, "/invoices"),
+                    Arguments.of(HttpMethod.PUT, "/invoices/" + INVOICE_ID_CREATE),
+                    Arguments.of(HttpMethod.PUT, "/invoices/" + INVOICE_ID_UPDATE),
+                    Arguments.of(HttpMethod.PATCH, "/invoices/" + INVOICE_ID_UPDATE)
+            );
+        }
+
+    }
+
+    /**
+     * Tests all validator violation cases:
+     * <ul>
+     * <li>Create entity without required attribute
+     * <li>Create entity without required (-to-one) relation
+     * <li>Update entity to remove/null required attribute
+     * <li>Update entity to remove/null required relation
+     * <li>Remove entity relation that is required on this side
+     * <li>Remove entity relation that is the target of a required one-to-one relation
+     * </ul>
+     */
+    @Nested
+    class ValidatorViolations {
+
+        @Test
+        void createEntityWithoutRequiredAttribute() throws Exception {
+            var customer = createCustomer();
+            mockMvc.perform(post("/invoices")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "counterparty": "/customers/%s"
+                                    }
+                                    """.formatted(customer.getId()))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @Test
+        void createEntityWithoutRequiredRelation() throws Exception {
+            mockMvc.perform(post("/invoices")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "number": "%s"
+                                    }
+                                    """.formatted(UUID.randomUUID()))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @Test
+        void updateEntityRemoveRequiredAttribute() throws Exception {
+            var invoice = createInvoice();
+            var customer = createCustomer();
+            mockMvc.perform(put("/invoices/{id}", invoice.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "counterparty": "/customers/%s"
+                                    }
+                                    """.formatted(customer.getId()))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+
+            mockMvc.perform(patch("/invoices/{id}", invoice.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "number": null
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @Test
+        void updateEntityRemoveRequiredRelation() throws Exception {
+            // for PUT, relations are ignored if they are not present
+            /*
+            mockMvc.perform(put("/invoices/{id}", INVOICE_ID_UPDATE)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                            {
+                                "number": "%s"
+                            }
+                            """.formatted(UUID.randomUUID()))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+             */
+
+            var invoice = createInvoice();
+            mockMvc.perform(patch("/invoices/{id}", invoice.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "counterparty": null
+                                    }
+                                    """)
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @Test
+        void removeRequiredEntityRelation_thisSide() throws Exception {
+            var invoice = createInvoice();
+            mockMvc.perform(delete("/invoices/{id}/counterparty", invoice.getId()))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+
+        @Test
+        @Disabled("Currently inverse-side updates are not persisted anyways")
+        void removeRequiredEntityRelation_otherSide(@Autowired RefundRepository refundRepository) throws Exception {
+            var invoice = createInvoice();
+            var refund = new Refund();
+            refund.setInvoice(createInvoice());
+            refundRepository.save(refund);
+            // Now there is a refund that references our invoice
+
+            mockMvc.perform(delete("/invoices/{id}/refund", invoice.getId()))
+                    .andExpect(MockMvcResultMatchers.status().isBadRequest());
+        }
+    }
+
+    /**
+     * Tests all deletion violation cases:
+     * <ul>
+     * <li>Delete entity that is the target of a required many-to-one relation
+     * <li>Delete entity that is the target of a required one-to-one relation
+     * </ul>
+     */
+    @Nested
+    class DeletionViolations {
+
+        @Test
+        void deleteEntity_targetOfRequiredManyToOneRelation() throws Exception {
+            var invoice = createInvoice();
+            // This customer is linked to the invoice
+            mockMvc.perform(delete("/customers/{id}", invoice.getCounterparty().getId()))
+                    .andExpect(MockMvcResultMatchers.status().isConflict());
+        }
+
+        @Test
+        void deleteEntity_targetOfRequiredOneToOneRelation(@Autowired CustomerRepository customerRepository,
+                @Autowired InvoiceRepository invoiceRepository, @Autowired RefundRepository refundRepository)
+                throws Exception {
+            var invoice = createInvoice();
+
+            var refund = new Refund();
+            refund.setInvoice(invoice);
+            refundRepository.save(refund);
+            // Now there is a refund that references our invoice
+
+            mockMvc.perform(delete("/invoices/{id}", invoice.getId()))
+                    .andExpect(MockMvcResultMatchers.status().isConflict());
+        }
+
+    }
+
+    /**
+     * Tests all database constraint cases:
+     * <ul>
+     * <li>Unique constraint violations (unique column value created/updated for the second time)
+     * <li>FK constraint violations
+     * </ul>
+     */
+    @Nested
+    class DatabaseConstraintViolations {
+
+        @Test
+        void uniqueConstraintViolation_create() throws Exception {
+            var customerVat = UUID.randomUUID();
+
+            // First time goes through
+            mockMvc.perform(post("/customers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s"
+                                    }
+                                    """.formatted(customerVat))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+
+            // Second time results in a unique constraint error
+            mockMvc.perform(post("/customers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s"
+                                    }
+                                    """.formatted(customerVat))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isConflict());
+        }
+
+        @Test
+        void uniqueConstraintViolation_update() throws Exception {
+            var customer = createCustomer();
+            var customerVat = UUID.randomUUID();
+
+            // Create goes through
+            mockMvc.perform(post("/customers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s"
+                                    }
+                                    """.formatted(customerVat))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isCreated());
+
+            // Update to same id fails
+            mockMvc.perform(patch("/customers/{id}", customer.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s"
+                                    }
+                                    """.formatted(customerVat))
+                    )
+                    .andExpect(MockMvcResultMatchers.status().isConflict());
+        }
+
+        @Test
+        @Disabled("cases are covered by constraints, so no direct way to check it")
+        void foreignKeyConstraintViolation() {
+
+        }
+
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -394,7 +394,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // This customer is linked to the invoice
             mockMvc.perform(delete("/customers/{id}", invoice.getCounterparty().getId()))
                     .andExpect(problemDetails()
-                            .withStatusCode(HttpStatus.CONFLICT)
+                            .withStatusCode(HttpStatus.BAD_REQUEST)
                             .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation")
                     );
         }
@@ -412,7 +412,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
 
             mockMvc.perform(delete("/invoices/{id}", invoice.getId()))
                     .andExpect(problemDetails()
-                            .withStatusCode(HttpStatus.CONFLICT)
+                            .withStatusCode(HttpStatus.BAD_REQUEST)
                             .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation")
                     );
         }
@@ -457,7 +457,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                     )
                     .andExpect(problemDetails()
                             .withStatusCode(HttpStatus.CONFLICT)
-                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation/unique")
+                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation/duplicate-value")
                     );
         }
 
@@ -490,7 +490,7 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                     )
                     .andExpect(problemDetails()
                             .withStatusCode(HttpStatus.CONFLICT)
-                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation/unique")
+                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation/duplicate-value")
                     );
         }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/JsonPropertyPathConverterTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/JsonPropertyPathConverterTest.java
@@ -1,0 +1,70 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import com.contentgrid.spring.data.rest.mapping.PlainMapping;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
+import com.contentgrid.spring.test.fixture.invoicing.model.Refund;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = InvoicingApplication.class)
+class JsonPropertyPathConverterTest {
+
+    @Autowired
+    @PlainMapping(followingAssociations = true)
+    DomainTypeMapping domainTypeMapping;
+
+    JsonPropertyPathConverter jsonPropertyPathConverter;
+
+    @BeforeEach
+    void setup() {
+        jsonPropertyPathConverter = new JsonPropertyPathConverter(domainTypeMapping);
+    }
+
+    @Test
+    void convertsDirectPathToJsonEquivalent_withoutAnnotation() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Invoice.class, "draft")).isEqualTo("draft");
+    }
+
+    @Test
+    void convertsDirectPathToJsonEquivalent_withJsonProperty() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Invoice.class, "contentLength")).isEqualTo(
+                "content_length");
+    }
+
+    @Test
+    void convertsDirectPathToJsonEquivalent_withJsonIgnore() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Invoice.class, "contentId")).isNull();
+    }
+
+    @Test
+    void convertsNestedPathToJsonEquivalent_withoutAnnotation() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Customer.class, "content.filename")).isEqualTo(
+                "content.filename");
+    }
+
+    @Test
+    void convertsNestedPathToJsonEquivalent_withJsonProperty() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Refund.class, "invoice.contentMimetype")).isEqualTo(
+                "invoice.content_mimetype");
+    }
+
+    @Test
+    void convertsNestedPathToJsonEquivalent_withJsonIgnore() {
+        assertThat(jsonPropertyPathConverter.fromJavaPropertyPath(Customer.class, "content.id")).isNull();
+    }
+
+    @Test
+    void convertNonExistingPath_throws() {
+        assertThatThrownBy(() -> jsonPropertyPathConverter.fromJavaPropertyPath(Customer.class, "unknownProperty"))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ProblemDetailsMockMvcMatchers.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ProblemDetailsMockMvcMatchers.java
@@ -1,0 +1,189 @@
+package com.contentgrid.spring.data.rest.problem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+import org.assertj.core.api.ThrowingConsumer;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.json.ProblemDetailJacksonMixin;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ProblemDetailsMockMvcMatchers {
+
+    private final static ObjectMapper objectMapper = new ObjectMapper();
+
+    static {
+        objectMapper.addMixIn(ProblemDetail.class, ProblemDetailJacksonMixin.class);
+    }
+
+    public static ProblemDetailsMatcher problemDetails() {
+        return new ProblemDetailsMatcher();
+    }
+
+    public static ValidationConstraintViolationMatcher validationConstraintViolation() {
+        return new ValidationConstraintViolationMatcher(List.of());
+    }
+
+    @With
+    @AllArgsConstructor
+    public static class ProblemDetailsMatcher implements ResultMatcher {
+
+        private final static String SENTINEL = "\0";
+        private final String type;
+        private final String title;
+        private final HttpStatusCode statusCode;
+
+        public ProblemDetailsMatcher() {
+            this(SENTINEL, SENTINEL, null);
+        }
+
+        ProblemDetail readProblemDetail(MvcResult result) throws IOException {
+            assertThat(result.getResponse().getContentType())
+                    .as("response Content-Type")
+                    .isEqualTo("application/problem+json");
+
+            var problemDetails = objectMapper.reader()
+                    .readValue(result.getResponse().getContentAsByteArray(), ProblemDetail.class);
+
+            if (statusCode != null) {
+                assertThat(result.getResponse().getStatus())
+                        .as("response status code")
+                        .isEqualTo(statusCode.value());
+                assertThat(problemDetails)
+                        .extracting(ProblemDetail::getStatus)
+                        .as("problem status")
+                        .isEqualTo(statusCode.value());
+            }
+
+            if (!Objects.equals(type, SENTINEL)) {
+                assertThat(problemDetails)
+                        .extracting(ProblemDetail::getType)
+                        .extracting(URI::toString)
+                        .as("problem type")
+                        .isEqualTo(type);
+            }
+            if (!Objects.equals(title, SENTINEL)) {
+                assertThat(problemDetails)
+                        .extracting(ProblemDetail::getTitle)
+                        .as("problem title")
+                        .isEqualTo(title);
+            }
+
+            return problemDetails;
+        }
+
+        @Override
+        public void match(MvcResult result) throws Exception {
+            readProblemDetail(result);
+        }
+    }
+
+    @AllArgsConstructor
+    public static class ValidationConstraintViolationMatcher implements ResultMatcher {
+
+        private final static ProblemDetailsMatcher PROBLEM_DETAILS_MATCHER = new ProblemDetailsMatcher()
+                .withStatusCode(HttpStatus.BAD_REQUEST)
+                .withType("https://contentgrid.com/rels/problem/integrity/validation-constraint-violation");
+
+        @With(AccessLevel.PRIVATE)
+        private final List<ErrorDescription> errors;
+
+        public ValidationConstraintViolationMatcher withError(ErrorDescription description) {
+            return withErrors(Stream.concat(
+                    errors.stream(),
+                    Stream.of(description)
+            ).toList());
+        }
+
+        public ValidationConstraintViolationMatcher withError(UnaryOperator<ErrorDescription> configurer) {
+            return withError(configurer.apply(new ErrorDescription()));
+        }
+
+        @Override
+        public void match(MvcResult result) throws Exception {
+            var details = PROBLEM_DETAILS_MATCHER.readProblemDetail(result);
+            var properties = details.getProperties();
+            assertThat(properties).containsKey("errors")
+                    .extractingByKey("errors")
+                    .isInstanceOf(List.class);
+
+            var errors = (List) properties.get("errors");
+
+            assertThat(errors)
+                    .satisfiesExactlyInAnyOrder(
+                            this.errors.stream().map(ErrorDescription::toSatisfies).toArray(ThrowingConsumer[]::new));
+
+        }
+
+        @RequiredArgsConstructor
+        public static class ErrorDescription {
+
+            private final static ThrowingConsumer<String> SENTINEL = (s) -> {
+            };
+            private final ThrowingConsumer<String> type;
+            private final ThrowingConsumer<String> title;
+            private final ThrowingConsumer<String> property;
+
+            public ErrorDescription() {
+                this(SENTINEL, SENTINEL, SENTINEL);
+            }
+
+            public ErrorDescription withType(ThrowingConsumer<String> type) {
+                return new ErrorDescription(type, this.title, this.property);
+            }
+
+            public ErrorDescription withTitle(ThrowingConsumer<String> title) {
+                return new ErrorDescription(this.type, title, this.property);
+            }
+
+            public ErrorDescription withProperty(ThrowingConsumer<String> property) {
+                return new ErrorDescription(this.type, this.title, property);
+            }
+
+            public ErrorDescription withType(String value) {
+                return withType(t -> assertThat(t).isEqualTo(value));
+            }
+
+            public ErrorDescription withTitle(String value) {
+                return withTitle(t -> assertThat(t).isEqualTo(value));
+            }
+
+            public ErrorDescription withProperty(String value) {
+                return withProperty(t -> assertThat(t).isEqualTo(value));
+            }
+
+            ThrowingConsumer<Map> toSatisfies() {
+                return (data) -> {
+                    assertThat(data)
+                            .extractingByKey("property")
+                            .satisfies(property);
+
+                    assertThat(data)
+                            .extractingByKey("type")
+                            .satisfies(type);
+
+                    assertThat(data)
+                            .extractingByKey("title")
+                            .satisfies(title);
+                };
+
+            }
+        }
+    }
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ProblemDetailsMockMvcMatchers.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ProblemDetailsMockMvcMatchers.java
@@ -99,7 +99,7 @@ public final class ProblemDetailsMockMvcMatchers {
 
         private final static ProblemDetailsMatcher PROBLEM_DETAILS_MATCHER = new ProblemDetailsMatcher()
                 .withStatusCode(HttpStatus.BAD_REQUEST)
-                .withType("https://contentgrid.com/rels/problem/integrity/validation-constraint-violation");
+                .withType("https://contentgrid.cloud/problems/integrity/validation-constraint-violation");
 
         @With(AccessLevel.PRIVATE)
         private final List<ErrorDescription> errors;


### PR DESCRIPTION
Using [problem details](https://www.rfc-editor.org/rfc/rfc7807) for reporting errors to the client allows for returning a more specific error to the client than HTTP status codes allow.

Clients can use the specific error codes to show a proper message to end-users in the UI, or to autonomously take action to rectify the cause of the error.

