### PR TITLE
Improve problem reporting for entity that is still referenced by required relations when it is deleted

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnEntityDelete.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnEntityDelete.java
@@ -1,0 +1,8 @@
+package com.contentgrid.spring.data.rest.validation;
+
+/**
+ * Jakarta Bean Validation group that marks constraints that are only checked before entity deletion
+ */
+public interface OnEntityDelete {
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -393,9 +393,8 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             var invoice = createInvoice();
             // This customer is linked to the invoice
             mockMvc.perform(delete("/customers/{id}", invoice.getCounterparty().getId()))
-                    .andExpect(problemDetails()
-                            .withStatusCode(HttpStatus.BAD_REQUEST)
-                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation")
+                    .andExpect(validationConstraintViolation()
+                            .withError(error -> error.withProperty("invoices"))
                     );
         }
 
@@ -411,9 +410,8 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
             // Now there is a refund that references our invoice
 
             mockMvc.perform(delete("/invoices/{id}", invoice.getId()))
-                    .andExpect(problemDetails()
-                            .withStatusCode(HttpStatus.BAD_REQUEST)
-                            .withType(PROBLEM_TYPE_PREFIX + "integrity/constraint-violation")
+                    .andExpect(validationConstraintViolation()
+                            .withError(error -> error.withProperty("refund"))
                     );
         }
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.OnEntityDelete;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
 import com.contentgrid.spring.querydsl.predicate.EqualsIgnoreCase;
@@ -8,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import jakarta.validation.constraints.NotNull;
 import java.time.Instant;
+import jakarta.validation.constraints.Size;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -67,6 +69,8 @@ public class Customer {
     @CollectionFilterParam
     @CollectionFilterParam(value = "invoices.$$id", predicate = EntityId.class, documented = false)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:invoices")
+    // Invoice#counterparty is required, this constraint ensures that there are no more invoices linked when deleting the customer
+    @Size(max = 0, groups = OnEntityDelete.class)
     private Set<Invoice> invoices = new HashSet<>();
 
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.OnEntityDelete;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
 import com.contentgrid.spring.querydsl.predicate.EqualsIgnoreCase;
@@ -10,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
@@ -103,6 +105,8 @@ public class Invoice {
 
     @OneToOne(mappedBy = "invoice")
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:refund")
+    @Null(groups = OnEntityDelete.class)
+    // Refund#invoice is required, this constraint ensures that there is no refund linked when deleting the invoice
     private Refund refund;
 
     public Invoice(String number, boolean draft, boolean paid, Customer counterparty, Set<Order> orders) {


### PR DESCRIPTION
Normally, this would result in a foreign key constraint violation, resulting in a generic constraint violation problem report. That doesn't help a lot, because it doesn't tell you *which* relation is still referencing your entity.

Using a separate validation group, we can verify that there are no entities referencing our entity anymore (thanks to the inverse relations), and raise a specific validation error in case the entity is still being referenced.
