### PR TITLE
Handle exceptions during processing audit messages

### DIFF
--- a/contentgrid-spring-audit-logging/src/main/java/com/contentgrid/spring/audit/AuditObservationHandler.java
+++ b/contentgrid-spring-audit-logging/src/main/java/com/contentgrid/spring/audit/AuditObservationHandler.java
@@ -6,10 +6,13 @@ import com.contentgrid.spring.audit.handler.AuditEventHandler;
 import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.ObservationHandler;
 import java.util.List;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.server.observation.ServerRequestObservationContext;
 
 @RequiredArgsConstructor
+@Slf4j
 public class AuditObservationHandler implements ObservationHandler<ServerRequestObservationContext> {
 
     private final List<AuditEventExtractor> auditEventExtractors;
@@ -25,14 +28,25 @@ public class AuditObservationHandler implements ObservationHandler<ServerRequest
         var event = createAuditEvent(context);
         if (event != null) {
             for (AuditEventHandler auditEventHandler : auditEventHandlers) {
-                auditEventHandler.handle(event);
+                try {
+                    auditEventHandler.handle(event);
+                } catch (Exception ex) {
+                    log.error("Audit event handler {} failed to process event {}", auditEventHandler, event, ex);
+                }
             }
         }
     }
 
     private AbstractAuditEvent createAuditEvent(ServerRequestObservationContext context) {
         var maybeEventBuilder = auditEventExtractors.stream()
-                .flatMap(e -> e.createEventBuilder(context).stream())
+                .flatMap(eventExtractor -> {
+                    try {
+                        return eventExtractor.createEventBuilder(context).stream();
+                    } catch (Exception ex) {
+                        log.error("Audit event extractor {} failed to process context", eventExtractor, ex);
+                        return Stream.empty();
+                    }
+                })
                 .findFirst();
 
         if (maybeEventBuilder.isEmpty()) {
@@ -41,7 +55,17 @@ public class AuditObservationHandler implements ObservationHandler<ServerRequest
 
         var eventBuilder = maybeEventBuilder.get();
         for (AuditEventExtractor tagExtractor : auditEventExtractors) {
-            eventBuilder = tagExtractor.enhance(context, eventBuilder);
+            try {
+                var newEventBuilder = tagExtractor.enhance(context, eventBuilder);
+                if (newEventBuilder != null) {
+                    eventBuilder = newEventBuilder;
+                } else {
+                    log.error("Audit event extractor {} failed to enhance event {}: returned a null eventBuilder",
+                            tagExtractor, eventBuilder);
+                }
+            } catch (Exception ex) {
+                log.error("Audit event extractor {} failed to enhance event {}", tagExtractor, eventBuilder, ex);
+            }
         }
 
         return eventBuilder.build();

--- a/contentgrid-spring-audit-logging/src/main/java/com/contentgrid/spring/audit/handler/messaging/MessageSendingAuditHandler.java
+++ b/contentgrid-spring-audit-logging/src/main/java/com/contentgrid/spring/audit/handler/messaging/MessageSendingAuditHandler.java
@@ -9,17 +9,14 @@ import org.springframework.messaging.core.MessageSendingOperations;
 
 @RequiredArgsConstructor
 public class MessageSendingAuditHandler implements AuditEventHandler {
+
     @NonNull
     private final MessageSendingOperations<String> messageSendingOperations;
 
-    @Nullable
+    @NonNull
     private final String destination;
 
     public void handle(AbstractAuditEvent auditEvent) {
-        if (destination == null) {
-            messageSendingOperations.convertAndSend(auditEvent);
-        } else {
-            messageSendingOperations.convertAndSend(destination, auditEvent);
-        }
+        messageSendingOperations.convertAndSend(destination, auditEvent);
     }
 }

--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/audit/ContentGridAuditMessagingAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/audit/ContentGridAuditMessagingAutoConfiguration.java
@@ -12,6 +12,7 @@ import io.cloudevents.CloudEvent;
 import io.cloudevents.spring.messaging.CloudEventMessageConverter;
 import java.net.URI;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -19,8 +20,10 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.core.annotation.Order;
 import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.core.AbstractMessageSendingTemplate;
 import org.springframework.messaging.core.MessageSendingOperations;
 
 @AutoConfiguration(
@@ -30,10 +33,14 @@ import org.springframework.messaging.core.MessageSendingOperations;
 @ConditionalOnClass({MessageSendingOperations.class, MessageSendingAuditHandler.class})
 @ConditionalOnBean(value = MessageSendingOperations.class, annotation = ContentGridMessaging.class)
 @EnableConfigurationProperties(ContentGridAuditMessagingProperties.class)
-@ConditionalOnProperty(value = "contentgrid.audit.messaging.enabled", matchIfMissing = true)
+@ConditionalOnProperty(prefix = ContentGridAuditMessagingAutoConfiguration.CONTENTGRID_AUDIT_MESSAGING, name = "enabled", matchIfMissing = true)
+@Slf4j
 public class ContentGridAuditMessagingAutoConfiguration {
 
+    public static final String CONTENTGRID_AUDIT_MESSAGING = "contentgrid.audit.messaging";
+
     @Bean
+    @ConditionalOnProperty(prefix = CONTENTGRID_AUDIT_MESSAGING, name = "destination")
     MessageSendingAuditHandler messageSendingAuditHandler(
             @ContentGridMessaging MessageSendingOperations<String> sendingOperations,
             ContentGridAuditMessagingProperties auditProperties
@@ -48,7 +55,7 @@ public class ContentGridAuditMessagingAutoConfiguration {
 
     @Bean
     @ContentGridMessaging
-    @ConditionalOnProperty("contentgrid.audit.messaging.source")
+    @ConditionalOnProperty(prefix = CONTENTGRID_AUDIT_MESSAGING, name = "source")
     @ConditionalOnClass({CloudEvent.class, AuditEventToCloudEventMessageConverter.class,
             CloudEventMessageConverter.class})
     @Order(10)
@@ -71,7 +78,7 @@ public class ContentGridAuditMessagingAutoConfiguration {
         return new AuditEventMessageConverter(objectMapper);
     }
 
-    @ConfigurationProperties("contentgrid.audit.messaging")
+    @ConfigurationProperties(CONTENTGRID_AUDIT_MESSAGING)
     @Data
     static class ContentGridAuditMessagingProperties {
 

--- a/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/audit/ContentGridAuditMessagingAutoConfigurationTest.java
+++ b/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/audit/ContentGridAuditMessagingAutoConfigurationTest.java
@@ -26,7 +26,8 @@ class ContentGridAuditMessagingAutoConfigurationTest {
                     ContentGridAuditLoggingAutoConfiguration.class,
                     ContentGridMessagingAutoConfiguration.class,
                     RepositoryRestMvcAutoConfiguration.class
-            ));
+            ))
+            .withPropertyValues("contentgrid.audit.messaging.destination=xyz");
 
     @Test
     void messagingHandlerEnabledWhenMessagingTemplateIsAvailable() {
@@ -34,6 +35,16 @@ class ContentGridAuditMessagingAutoConfigurationTest {
                 .withUserConfiguration(AmqpServiceConnection.class)
                 .run(context -> {
                     assertThat(context).hasSingleBean(MessageSendingAuditHandler.class);
+                });
+    }
+
+    @Test
+    void messagingHandlerDisabledWhenDestinationIsMissing() {
+        contextRunner.withConfiguration(AutoConfigurations.of(RabbitAutoConfiguration.class))
+                .withUserConfiguration(AmqpServiceConnection.class)
+                .withPropertyValues("contentgrid.audit.messaging.destination=false")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(MessageSendingAuditHandler.class);
                 });
     }
 


### PR DESCRIPTION
- Ensure that AuditObservationHandler does not throw exceptions
- Disable MessageSendingAuditHandler when no destination is configured
