### PR TITLE
Make cg:entity, cg:relation & cg:content links always an array

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - spring-boot-version: 3.1.+
+          - spring-boot-version: 3.2.+
             experimental: false
           - spring-boot-version: 3.+
             experimental: true

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -15,14 +15,18 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.data.rest.webmvc.mapping.LinkCollector;
 import org.springframework.hateoas.CollectionModel;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationCustomizer;
 import org.springframework.hateoas.mediatype.MessageResolver;
 import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.HalConfiguration;
+import org.springframework.hateoas.mediatype.hal.HalConfiguration.RenderSingleLinks;
 import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.server.LinkRelationProvider;
 import org.springframework.hateoas.server.RepresentationModelProcessor;
 
 @Configuration(proxyBeanMethods = false)
 public class ContentGridSpringDataLinksConfiguration {
+
     @Bean
     RepositoryRestConfigurer contentGridLinkCollectorConfigurer(
             ObjectProvider<ContentGridLinkCollector> collectors
@@ -43,6 +47,14 @@ public class ContentGridSpringDataLinksConfiguration {
     @Bean
     CurieProviderCustomizer contentGridCurieProviderCustomizer() {
         return CurieProviderCustomizer.register(ContentGridLinkRelations.CURIE, ContentGridLinkRelations.TEMPLATE);
+    }
+
+    @Bean
+    MediaTypeConfigurationCustomizer<HalConfiguration> contentGridLinksMediaTypeConfigurationCustomizer() {
+        return halConfiguration -> halConfiguration
+                .withRenderSingleLinksFor(ContentGridLinkRelations.CONTENT, RenderSingleLinks.AS_ARRAY)
+                .withRenderSingleLinksFor(ContentGridLinkRelations.RELATION, RenderSingleLinks.AS_ARRAY)
+                .withRenderSingleLinksFor(ContentGridLinkRelations.ENTITY, RenderSingleLinks.AS_ARRAY);
     }
 
     @Bean


### PR DESCRIPTION
HAL specifies that links should not switch between a list and a single value.
`cg:entity`, `cg:relation` & `cg:content` are always used in a context where there are potentially multiple entries present.

Because this feature uses the new `MediaTypeConfigurationCustomizer` from spring-hateoas 2.2, **support for Spring Boot 3.1 is dropped.**
