### PR TITLE
Use new MediaTypeConfigurationCustomizer to customize HalFormsConfiguration

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -3,6 +3,7 @@ package com.contentgrid.spring.boot.autoconfigure.data.web;
 import com.contentgrid.spring.data.rest.affordances.ContentGridSpringDataRestAffordancesConfiguration;
 import com.contentgrid.spring.data.rest.hal.ContentGridCurieConfiguration;
 import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import com.contentgrid.spring.data.rest.hal.forms.ContentGridHalFormsConfiguration;
 import com.contentgrid.spring.data.rest.links.ContentGridSpringContentRestLinksConfiguration;
 import com.contentgrid.spring.data.rest.links.ContentGridSpringDataLinksConfiguration;
 import com.contentgrid.spring.data.rest.problem.ContentGridProblemDetailsConfiguration;
@@ -30,6 +31,7 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguratio
         ContentGridSpringDataRestProfileConfiguration.class,
         ContentGridSpringDataRestAffordancesConfiguration.class,
         ContentGridSpringDataRestValidationConfiguration.class,
+        ContentGridHalFormsConfiguration.class,
         ContentGridProblemDetailsConfiguration.class
 })
 @AutoConfigureAfter(

--- a/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
+++ b/contentgrid-spring-boot-autoconfigure/src/test/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfigurationTest.java
@@ -39,17 +39,6 @@ class ContentGridSpringDataRestAutoConfigurationTest {
     }
 
     @Test
-    void checkContentGridProfile_halConfiguration_used() {
-        var halConfiguration = new HalConfiguration();
-        contextRunner
-                .withBean(HalConfiguration.class, () -> halConfiguration)
-                .run(context -> {
-                    assertThat(context).hasSingleBean(HalFormsConfiguration.class);
-                    assertThat(context.getBean(HalFormsConfiguration.class).getHalConfiguration()).isSameAs(halConfiguration);
-                });
-    }
-
-    @Test
     void when_contentGridSpringDataRest_isNotOnClasspath() {
         contextRunner
                 .withClassLoader(new FilteredClassLoader(ContentGridSpringDataRestConfiguration.class))

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
@@ -1,0 +1,24 @@
+package com.contentgrid.spring.data.rest.hal.forms;
+
+import com.contentgrid.spring.data.rest.mapping.ContentGridDomainTypeMappingConfiguration;
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import com.contentgrid.spring.data.rest.mapping.FormMapping;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationCustomizer;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsConfiguration;
+import org.springframework.hateoas.server.EntityLinks;
+
+@Configuration(proxyBeanMethods = false)
+@Import(ContentGridDomainTypeMappingConfiguration.class)
+public class ContentGridHalFormsConfiguration {
+
+    @Bean
+    MediaTypeConfigurationCustomizer<HalFormsConfiguration> contentGridHalFormsRelationFieldOptionsCustomizer(
+            @FormMapping DomainTypeMapping domainTypeMapping,
+            EntityLinks entityLinks
+    ) {
+        return new HalFormsRelationFieldOptionsCustomizer(domainTypeMapping, entityLinks);
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsRelationFieldOptionsCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsRelationFieldOptionsCustomizer.java
@@ -1,0 +1,45 @@
+package com.contentgrid.spring.data.rest.hal.forms;
+
+import com.contentgrid.spring.data.rest.mapping.Container;
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationCustomizer;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsConfiguration;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsOptions;
+import org.springframework.hateoas.server.EntityLinks;
+
+@RequiredArgsConstructor
+public class HalFormsRelationFieldOptionsCustomizer implements MediaTypeConfigurationCustomizer<HalFormsConfiguration> {
+
+    private final DomainTypeMapping domainTypeMapping;
+    private final EntityLinks entityLinks;
+
+    @Override
+    public HalFormsConfiguration customize(HalFormsConfiguration configuration) {
+        for (Class<?> domainType : domainTypeMapping) {
+            var container = domainTypeMapping.forDomainType(domainType);
+            configuration = customizeConfiguration(configuration, domainType, container);
+        }
+        return configuration;
+    }
+
+    private HalFormsConfiguration customizeConfiguration(HalFormsConfiguration configuration, Class<?> domainType,
+            Container container) {
+        var configAtomic = new AtomicReference<>(configuration);
+        container.doWithAssociations(association -> {
+            configAtomic.updateAndGet(
+                    config -> config.withOptions(domainType, association.getName(), metadata -> {
+                        var collectionLink = entityLinks.linkToCollectionResource(
+                                association.getTypeInformation().getRequiredActualType().getType()).expand();
+
+                        return HalFormsOptions.remote(collectionLink)
+                                .withMinItems(association.isRequired() ? 1L : 0L)
+                                .withMaxItems(association.getTypeInformation().isCollectionLike() ? null : 1L)
+                                // This is a JSON pointer into the item
+                                .withValueField("/_links/self/href");
+                    }));
+        });
+        return configAtomic.get();
+    }
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
@@ -1,0 +1,112 @@
+package com.contentgrid.spring.data.rest.hal.forms;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class,
+})
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+class ContentGridHalFormsConfigurationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void createFormFieldForToOneRelationLinksToReferredResource() throws Exception {
+        mockMvc.perform(get("/profile/refunds").accept(MediaTypes.HAL_FORMS_JSON))
+                .andExpectAll(
+                        content().json("""
+                                {
+                                    _templates: {
+                                        "create-form": {
+                                            properties: [
+                                                {
+                                                    name: "invoice",
+                                                    required: true,
+                                                    type: "url",
+                                                    options: {
+                                                        link: {
+                                                            href: "http://localhost/invoices"
+                                                        },
+                                                        minItems: 1,
+                                                        maxItems: 1
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                                """)
+                );
+    }
+
+    @Test
+    void linkRelationFormFieldForToManyRelationLinksToReferredResource() throws Exception {
+        var createdCustomer = mockMvc.perform(
+                        post("/customers").contentType(MediaType.APPLICATION_JSON).content("""
+                                {
+                                    "vat": "BE123"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mockMvc.perform(get(createdCustomer).accept(MediaTypes.HAL_FORMS_JSON)).andExpect(
+                content().json("""
+                        {
+                            _templates: {
+                                "add-orders": {
+                                    method: "POST",
+                                    contentType: "text/uri-list",
+                                    properties: [
+                                        {
+                                            name: "orders",
+                                            type: "url",
+                                            options: {
+                                                link: {
+                                                    href: "http://localhost/orders"
+                                                },
+                                                minItems: 0
+                                            }
+                                        }
+                                    ]
+                                },
+                                "add-invoices": {
+                                    method: "POST",
+                                    contentType: "text/uri-list",
+                                    properties: [
+                                        {
+                                            name: "invoices",
+                                            type: "url",
+                                            options: {
+                                                link: {
+                                                    href: "http://localhost/invoices"
+                                                },
+                                                minItems: 0
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                        """)
+        );
+    }
+
+}


### PR DESCRIPTION
The MediaTypeConfigurationCustomizer is a new way to configure HalFormsConfiguration without creating the whole configuration in one place.
Since we only need to configure hal-forms options on some fields, it is a good candidate to be moved to the MediaTypeConfigurationCustomizer approach.
 
Also add tests that check that the options are added correctly to relations.

