### PR TITLE
Add test for generated contentgrid application with the contentgrid linkrels/curies enabled

### DIFF
--- a/integration-tests/integration-tests-spring/src/test/java/com/contentgrid/userapps/holmes/dcm/DcmApiApplicationTestsWithContentGridLinkRels.java
+++ b/integration-tests/integration-tests-spring/src/test/java/com/contentgrid/userapps/holmes/dcm/DcmApiApplicationTestsWithContentGridLinkRels.java
@@ -1,0 +1,29 @@
+package com.contentgrid.userapps.holmes.dcm;
+
+import com.contentgrid.spring.data.rest.hal.CurieProviderCustomizer;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootTest(properties = {
+        "spring.content.storage.type.default=fs"
+})
+class DcmApiApplicationTestsWithContentGridLinkRels {
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        CurieProviderCustomizer datamodelCurie() {
+            return CurieProviderCustomizer.register("d", "urn:example:datamodel:{suffix}");
+        }
+
+    }
+
+    @Test
+    void contextLoads() {
+    }
+
+
+}


### PR DESCRIPTION
This ensures that the integration tests cover the whole customized links configurations as well
