### PR TITLE
Move etag header tests to separate test file

### DIFF
--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,9 +43,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 
 @Slf4j
-@SpringBootTest(properties = {
-        "server.servlet.encoding.enabled=false" // disables mock-mvc enforcing charset in request
-})
+@SpringBootTest
 @ContextConfiguration(classes = {
         InvoicingApplication.class,
 })
@@ -261,6 +260,7 @@ public class OptimisticLockingTest {
         }
 
         @Test
+        @Disabled("ACC-1313")
         void postMultipartInvoiceAndContent_shouldSetETag_http201() throws Exception {
             var file = new MockMultipartFile("content", "content.txt", MIMETYPE_PLAINTEXT_UTF8,
                     UNICODE_TEXT.getBytes(StandardCharsets.UTF_8));
@@ -359,6 +359,7 @@ public class OptimisticLockingTest {
         }
 
         @Test
+        @Disabled("ACC-1313")
         void postMultipartCustomerAndContent_shouldSetETag_http201() throws Exception {
             var file = new MockMultipartFile("content", "content.txt", MIMETYPE_PLAINTEXT_UTF8,
                     UNICODE_TEXT.getBytes(StandardCharsets.UTF_8));

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -36,6 +36,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.content.commons.property.PropertyPath;
+import org.springframework.data.rest.webmvc.support.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
@@ -60,7 +61,7 @@ public class OptimisticLockingTest {
 
     static int INVOICE_1_VERSION;
     static int XENIT_VERSION;
-    static final String INVALID_VERSION = "\"INVALID\"";
+    static final ETag INVALID_VERSION = ETag.from("INVALID");
 
     private static final String EXT_ASCII_TEXT = "L'éducation doit être gratuite.";
     private static final String UNICODE_TEXT = "Some unicode text 💩";
@@ -124,13 +125,13 @@ public class OptimisticLockingTest {
                 .andExpect(headers().etag().exists());
     }
 
-    void checkETagUnchanged(String url, String original) throws Exception {
+    void checkETagUnchanged(String url, ETag original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andExpect(headers().etag().isEqualTo(original));
     }
 
-    void checkETagChanged(String url, String original) throws Exception {
+    void checkETagChanged(String url, ETag original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andExpect(headers().etag().isNotEqualTo(original));

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -124,16 +124,16 @@ public class OptimisticLockingTest {
                 .andExpect(headers().etag().exists());
     }
 
-    void checkETagUnchanged(String url, int original) throws Exception {
+    void checkETagUnchanged(String url, String original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
-                .andExpect(headers().etag().isEqualTo(toETag(original)));
+                .andExpect(headers().etag().isEqualTo(original));
     }
 
-    void checkETagChanged(String url, int original) throws Exception {
+    void checkETagChanged(String url, String original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
-                .andExpect(headers().etag().isNotEqualTo(toETag(original)));
+                .andExpect(headers().etag().isNotEqualTo(original));
     }
 
     @AfterEach
@@ -194,7 +194,7 @@ public class OptimisticLockingTest {
                                     """.formatted(INVOICE_NUMBER_1)))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -210,7 +210,7 @@ public class OptimisticLockingTest {
                                     """.formatted(INVOICE_NUMBER_1)))
                     .andExpect(status().isNoContent());
 
-            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagChanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -219,7 +219,7 @@ public class OptimisticLockingTest {
                             .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -245,7 +245,7 @@ public class OptimisticLockingTest {
                             .content(UNICODE_TEXT))
                     .andExpect(status().isCreated());
 
-            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagChanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -257,7 +257,7 @@ public class OptimisticLockingTest {
                             .content(UNICODE_TEXT))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -291,7 +291,7 @@ public class OptimisticLockingTest {
                             .content(EXT_ASCII_TEXT))
                     .andExpect(status().isOk());
 
-            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagChanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -306,7 +306,7 @@ public class OptimisticLockingTest {
                             .content(EXT_ASCII_TEXT))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -317,7 +317,7 @@ public class OptimisticLockingTest {
                             .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION)))
                     .andExpect(status().isNoContent());
 
-            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagChanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
 
         @Test
@@ -328,7 +328,7 @@ public class OptimisticLockingTest {
                             .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, toETag(INVOICE_1_VERSION));
         }
     }
 
@@ -344,7 +344,7 @@ public class OptimisticLockingTest {
                             .content(UNICODE_TEXT))
                     .andExpect(status().isCreated());
 
-            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagChanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
 
         @Test
@@ -356,7 +356,7 @@ public class OptimisticLockingTest {
                             .content(UNICODE_TEXT))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagUnchanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
 
         @Test
@@ -390,7 +390,7 @@ public class OptimisticLockingTest {
                             .content(EXT_ASCII_TEXT))
                     .andExpect(status().isOk());
 
-            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagChanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
 
         @Test
@@ -405,7 +405,7 @@ public class OptimisticLockingTest {
                             .content(EXT_ASCII_TEXT))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagUnchanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
 
         @Test
@@ -416,7 +416,7 @@ public class OptimisticLockingTest {
                             .header(HttpHeaders.IF_MATCH, toETag(XENIT_VERSION)))
                     .andExpect(status().isNoContent());
 
-            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagChanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
 
         @Test
@@ -427,7 +427,7 @@ public class OptimisticLockingTest {
                             .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
                     .andExpect(status().isPreconditionFailed());
 
-            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+            checkETagUnchanged("/customers/" + XENIT_ID, toETag(XENIT_VERSION));
         }
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
+import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
@@ -84,7 +85,7 @@ public class OptimisticLockingTest {
     @BeforeEach
     void setupTestData() {
         var xenit = customers.save(
-                new Customer(null, 0, "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
+                new Customer(null, 0, new AuditMetadata(), "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
                         new HashSet<>()));
 
         XENIT_ID = xenit.getId();
@@ -126,13 +127,13 @@ public class OptimisticLockingTest {
     void checkETagUnchanged(String url, int original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
-                .andExpect(headers().etag().isEqualTo(original));
+                .andExpect(headers().etag().isEqualTo(toETag(original)));
     }
 
     void checkETagChanged(String url, int original) throws Exception {
         mockMvc.perform(get(url))
                 .andExpect(status().isOk())
-                .andExpect(headers().etag().isNotEqualTo(original));
+                .andExpect(headers().etag().isNotEqualTo(toETag(original)));
     }
 
     @AfterEach
@@ -150,7 +151,7 @@ public class OptimisticLockingTest {
                             .accept(MediaType.APPLICATION_JSON)
                             .header(HttpHeaders.IF_NONE_MATCH, INVALID_VERSION))
                     .andExpect(status().isOk())
-                    .andExpect(headers().etag().isEqualTo(INVOICE_1_VERSION));
+                    .andExpect(headers().etag().isEqualTo(toETag(INVOICE_1_VERSION)));
         }
 
         @Test

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -1,0 +1,431 @@
+package com.contentgrid.spring.data.rest.etag;
+
+import static com.contentgrid.spring.test.matchers.ETagHeaderMatcher.toETag;
+import static com.contentgrid.spring.test.matchers.ExtendedHeaderResultMatchers.headers;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
+import com.contentgrid.spring.test.fixture.invoicing.repository.CustomerRepository;
+import com.contentgrid.spring.test.fixture.invoicing.repository.InvoiceRepository;
+import com.contentgrid.spring.test.fixture.invoicing.store.CustomerContentStore;
+import com.contentgrid.spring.test.fixture.invoicing.store.InvoiceContentStore;
+import com.contentgrid.spring.test.security.WithMockJwt;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.content.commons.property.PropertyPath;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+
+@Slf4j
+@SpringBootTest(properties = {
+        "server.servlet.encoding.enabled=false" // disables mock-mvc enforcing charset in request
+})
+@ContextConfiguration(classes = {
+        InvoicingApplication.class,
+})
+@EnableAutoConfiguration(exclude = EventsAutoConfiguration.class)
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+@WithMockJwt
+public class OptimisticLockingTest {
+
+    static final String INVOICE_NUMBER_1 = "I-2022-0001";
+    static final String ORG_XENIT_VAT = "BE0887582365";
+    static UUID INVOICE_1_ID;
+    static UUID XENIT_ID;
+
+    static int INVOICE_1_VERSION;
+    static int XENIT_VERSION;
+    static final String INVALID_VERSION = "\"INVALID\"";
+
+    private static final String EXT_ASCII_TEXT = "L'éducation doit être gratuite.";
+    private static final String UNICODE_TEXT = "Some unicode text 💩";
+    private static final String MIMETYPE_PLAINTEXT_LATIN1 = "text/plain;charset=ISO-8859-1";
+    private static final String MIMETYPE_PLAINTEXT_UTF8 = "text/plain;charset=UTF-8";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    CustomerRepository customers;
+
+    @Autowired
+    InvoiceRepository invoices;
+
+    @Autowired
+    InvoiceContentStore invoicesContent;
+
+    @Autowired
+    CustomerContentStore customersContent;
+
+    @BeforeEach
+    void setupTestData() {
+        var xenit = customers.save(
+                new Customer(null, 0, "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
+                        new HashSet<>()));
+
+        XENIT_ID = xenit.getId();
+        XENIT_VERSION = xenit.getVersion();
+
+        var invoice = invoices.save(
+                new Invoice(INVOICE_NUMBER_1, true, false, xenit, new HashSet<>()));
+
+        INVOICE_1_ID = invoice.getId();
+        INVOICE_1_VERSION = invoice.getVersion();
+    }
+
+    void setupContentProperties() {
+        var stream = new ByteArrayInputStream(EXT_ASCII_TEXT.getBytes(StandardCharsets.ISO_8859_1));
+
+        var customer = customers.findById(XENIT_ID).orElseThrow();
+        customersContent.setContent(customer, PropertyPath.from("content"), stream);
+        customer.getContent().setMimetype(MIMETYPE_PLAINTEXT_LATIN1);
+        customer.getContent().setFilename("content.txt");
+        customer = customers.save(customer);
+
+        XENIT_VERSION = customer.getVersion();
+
+        var invoice = invoices.findById(INVOICE_1_ID).orElseThrow();
+        invoicesContent.setContent(invoice, PropertyPath.from("content"), stream);
+        invoice.setContentMimetype(MIMETYPE_PLAINTEXT_LATIN1);
+        invoice.setContentFilename("content.txt");
+        invoice = invoices.save(invoice);
+
+        INVOICE_1_VERSION = invoice.getVersion();
+    }
+
+    void checkETagExists(String url) throws Exception {
+        mockMvc.perform(get(url))
+                .andExpect(status().isOk())
+                .andExpect(headers().etag().exists());
+    }
+
+    void checkETagUnchanged(String url, int original) throws Exception {
+        mockMvc.perform(get(url))
+                .andExpect(status().isOk())
+                .andExpect(headers().etag().isEqualTo(original));
+    }
+
+    void checkETagChanged(String url, int original) throws Exception {
+        mockMvc.perform(get(url))
+                .andExpect(status().isOk())
+                .andExpect(headers().etag().isNotEqualTo(original));
+    }
+
+    @AfterEach
+    void cleanupTestData() {
+        invoices.deleteAll();
+        customers.deleteAll();
+    }
+
+    @Nested
+    class ItemResource {
+
+        @Test
+        void getInvoice_withInvalidIfNoneMatch_http200() throws Exception {
+            mockMvc.perform(get("/invoices/" + INVOICE_1_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header(HttpHeaders.IF_NONE_MATCH, INVALID_VERSION))
+                    .andExpect(status().isOk())
+                    .andExpect(headers().etag().isEqualTo(INVOICE_1_VERSION));
+        }
+
+        @Test
+        void getInvoice_withMatchingIfNoneMatch_http304() throws Exception {
+            mockMvc.perform(get("/invoices/" + INVOICE_1_ID)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .header(HttpHeaders.IF_NONE_MATCH, toETag(INVOICE_1_VERSION)))
+                    .andExpect(status().isNotModified());
+        }
+
+        @Test
+        void postInvoice_shouldSetETag() throws Exception {
+            var response = mockMvc.perform(post("/invoices")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "number": "I-2022-0003",
+                                        "counterparty": "/customers/%s"
+                                    }
+                                    """.formatted(XENIT_ID)))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            var location = Objects.requireNonNull(response.getResponse().getHeader(HttpHeaders.LOCATION));
+            var invoiceId = StringUtils.substringAfterLast(location, "/");
+
+            checkETagExists("/invoices/" + invoiceId);
+        }
+
+        @Test
+        void putInvoice_withInvalidIfMatch_http412() throws Exception {
+            mockMvc.perform(put("/invoices/{id}", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "number": "%s",
+                                        "paid": true
+                                    }
+                                    """.formatted(INVOICE_NUMBER_1)))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void putInvoice_withMatchingIfMatch_http200() throws Exception {
+            mockMvc.perform(put("/invoices/{id}", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                        "number": "%s",
+                                        "paid": true
+                                    }
+                                    """.formatted(INVOICE_NUMBER_1)))
+                    .andExpect(status().isNoContent());
+
+            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void deleteInvoice_withInvalidIfMatch_http412() throws Exception {
+            mockMvc.perform(delete("/invoices/{id}", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void deleteInvoice_withMatchingIfMatch_http204() throws Exception {
+            mockMvc.perform(delete("/invoices/{id}", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION)))
+                    .andExpect(status().isNoContent());
+
+            mockMvc.perform(get("/invoices/{id}", INVOICE_1_ID))
+                    .andExpect(status().isNotFound());
+        }
+    }
+
+    @Nested
+    class InlineContentProperty {
+
+        @Test
+        void postInvoiceContent_withMatchingIfMatch_http201() throws Exception {
+            mockMvc.perform(post("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION))
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .content(UNICODE_TEXT))
+                    .andExpect(status().isCreated());
+
+            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void postInvoiceContent_withInvalidIfMatch_http412() throws Exception {
+            mockMvc.perform(post("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .content(UNICODE_TEXT))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void postMultipartInvoiceAndContent_shouldSetETag_http201() throws Exception {
+            var file = new MockMultipartFile("content", "content.txt", MIMETYPE_PLAINTEXT_UTF8,
+                    UNICODE_TEXT.getBytes(StandardCharsets.UTF_8));
+
+            var response = mockMvc.perform(multipart(HttpMethod.POST, "/invoices")
+                            .file(file)
+                            .param("number", "I-2022-0003")
+                            .param("counterparty", "/customers/" + XENIT_ID))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            var location = Objects.requireNonNull(response.getResponse().getHeader(HttpHeaders.LOCATION));
+            var invoiceId = StringUtils.substringAfterLast(location, "/");
+
+            checkETagExists("/invoices/" + invoiceId);
+        }
+
+        @Test
+        void putInvoiceContent_withMatchingIfMatch_http200() throws Exception {
+            setupContentProperties();
+
+            // update content, ONLY changing the charset
+            mockMvc.perform(put("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION))
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content(EXT_ASCII_TEXT))
+                    .andExpect(status().isOk());
+
+            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void putInvoiceContent_withInvalidIfMatch_http412() throws Exception {
+            setupContentProperties();
+
+            // update content, ONLY changing the charset
+            mockMvc.perform(put("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content(EXT_ASCII_TEXT))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void deleteInvoiceContent_withMatchingIfMatch_http200() throws Exception {
+            setupContentProperties();
+
+            mockMvc.perform(delete("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(INVOICE_1_VERSION)))
+                    .andExpect(status().isNoContent());
+
+            checkETagChanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+
+        @Test
+        void deleteInvoiceContent_withInvalidIfMatch_http412() throws Exception {
+            setupContentProperties();
+
+            mockMvc.perform(delete("/invoices/{id}/content", INVOICE_1_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/invoices/" + INVOICE_1_ID, INVOICE_1_VERSION);
+        }
+    }
+
+    @Nested
+    class EmbeddedContentProperty {
+
+        @Test
+        void postCustomerContent_withMatchingIfMatch_http201() throws Exception {
+            mockMvc.perform(post("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(XENIT_VERSION))
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .content(UNICODE_TEXT))
+                    .andExpect(status().isCreated());
+
+            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+
+        @Test
+        void postCustomerContent_withInvalidIfMatch_http412() throws Exception {
+            mockMvc.perform(post("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .content(UNICODE_TEXT))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+
+        @Test
+        void postMultipartCustomerAndContent_shouldSetETag_http201() throws Exception {
+            var file = new MockMultipartFile("content", "content.txt", MIMETYPE_PLAINTEXT_UTF8,
+                    UNICODE_TEXT.getBytes(StandardCharsets.UTF_8));
+
+            var response = mockMvc.perform(multipart(HttpMethod.POST, "/customers")
+                            .file(file)
+                            .param("name", "Example")
+                            .param("vat", "BE_EXAMPLE"))
+                    .andExpect(status().isCreated())
+                    .andReturn();
+
+            var location = Objects.requireNonNull(response.getResponse().getHeader(HttpHeaders.LOCATION));
+            var customerId = StringUtils.substringAfterLast(location, "/");
+
+            checkETagExists("/customers/" + customerId);
+        }
+
+        @Test
+        void putCustomerContent_withMatchingIfMatch_http200() throws Exception {
+            setupContentProperties();
+
+            // update content, ONLY changing the charset
+            mockMvc.perform(put("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(XENIT_VERSION))
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content(EXT_ASCII_TEXT))
+                    .andExpect(status().isOk());
+
+            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+
+        @Test
+        void putCustomerContent_withInvalidIfMatch_http412() throws Exception {
+            setupContentProperties();
+
+            // update content, ONLY changing the charset
+            mockMvc.perform(put("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION)
+                            .characterEncoding(StandardCharsets.UTF_8)
+                            .contentType(MediaType.TEXT_PLAIN)
+                            .content(EXT_ASCII_TEXT))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+
+        @Test
+        void deleteCustomerContent_withMatchingIfMatch_http200() throws Exception {
+            setupContentProperties();
+
+            mockMvc.perform(delete("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, toETag(XENIT_VERSION)))
+                    .andExpect(status().isNoContent());
+
+            checkETagChanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+
+        @Test
+        void deleteCustomerContent_withInvalidIfMatch_http412() throws Exception {
+            setupContentProperties();
+
+            mockMvc.perform(delete("/customers/{id}/content", XENIT_ID)
+                            .header(HttpHeaders.IF_MATCH, INVALID_VERSION))
+                    .andExpect(status().isPreconditionFailed());
+
+            checkETagUnchanged("/customers/" + XENIT_ID, XENIT_VERSION);
+        }
+    }
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultMatcher;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
-public class EtagHeaderMatcher {
+public class ETagHeaderMatcher {
 
-    public static String toEtag(int version) {
+    public static String toETag(int version) {
         return "\"%d\"".formatted(version);
     }
 
@@ -20,11 +20,11 @@ public class EtagHeaderMatcher {
     }
 
     public ResultMatcher isEqualTo(int expected) {
-        return header().string(HttpHeaders.ETAG, toEtag(expected));
+        return header().string(HttpHeaders.ETAG, toETag(expected));
     }
 
     public ResultMatcher isNotEqualTo(int notExpected) {
-        var matcher = not(toEtag(notExpected));
+        var matcher = not(toETag(notExpected));
         return header().string(HttpHeaders.ETAG, matcher);
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
@@ -5,26 +5,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.rest.webmvc.support.ETag;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.ResultMatcher;
 
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
 public class ETagHeaderMatcher {
 
-    public static String toETag(int version) {
-        return "\"%d\"".formatted(version);
+    public static ETag toETag(int version) {
+        return ETag.from(String.valueOf(version));
     }
 
     public ResultMatcher exists() {
         return header().exists(HttpHeaders.ETAG);
     }
 
-    public ResultMatcher isEqualTo(String expected) {
-        return header().string(HttpHeaders.ETAG, expected);
+    public ResultMatcher isEqualTo(ETag expected) {
+        return header().string(HttpHeaders.ETAG, expected.toString());
     }
 
-    public ResultMatcher isNotEqualTo(String notExpected) {
-        var matcher = not(notExpected);
+    public ResultMatcher isNotEqualTo(ETag notExpected) {
+        var matcher = not(notExpected.toString());
         return header().string(HttpHeaders.ETAG, matcher);
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ETagHeaderMatcher.java
@@ -19,12 +19,12 @@ public class ETagHeaderMatcher {
         return header().exists(HttpHeaders.ETAG);
     }
 
-    public ResultMatcher isEqualTo(int expected) {
-        return header().string(HttpHeaders.ETAG, toETag(expected));
+    public ResultMatcher isEqualTo(String expected) {
+        return header().string(HttpHeaders.ETAG, expected);
     }
 
-    public ResultMatcher isNotEqualTo(int notExpected) {
-        var matcher = not(toETag(notExpected));
+    public ResultMatcher isNotEqualTo(String notExpected) {
+        var matcher = not(notExpected);
         return header().string(HttpHeaders.ETAG, matcher);
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ExtendedHeaderResultMatchers.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/matchers/ExtendedHeaderResultMatchers.java
@@ -12,7 +12,7 @@ public class ExtendedHeaderResultMatchers extends HeaderResultMatchers {
         return new LocationHeaderMatcher();
     }
 
-    public EtagHeaderMatcher etag() {
-        return new EtagHeaderMatcher();
+    public ETagHeaderMatcher etag() {
+        return new ETagHeaderMatcher();
     }
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Version;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
@@ -34,9 +33,6 @@ public class Order {
     @GeneratedValue(strategy = GenerationType.AUTO)
     @JsonProperty(access = Access.READ_ONLY)
     private UUID id;
-
-    @Version
-    private int version;
 
     @ManyToOne
     @JoinColumn(name = "customer")

--- a/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/EntityChangeHibernateEventListenerTest.java
+++ b/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/EntityChangeHibernateEventListenerTest.java
@@ -171,8 +171,7 @@ class EntityChangeHibernateEventListenerTest {
 
         assertThat(testMessageHandler.messages()).satisfiesExactly(
                 checkEvent("create", Order.class),
-                checkEvent("create", PromotionCampaign.class),
-                checkEvent("update", Order.class)
+                checkEvent("create", PromotionCampaign.class)
         );
     }
 


### PR DESCRIPTION
Move optimistic locking tests about `If-Match` and `ETag` headers from `InvoicingApplicationTest` to a new file