### PR TITLE
Fix many-to-many relations to same target entity are mixed-up when following a relation

### DIFF
--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
@@ -87,6 +87,9 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
                 },
                 promos -> {
                     assertThat(promos.getName()).isEqualTo("promos");
+                },
+                manualPromos -> {
+                    assertThat(manualPromos.getName()).isEqualTo("manualPromos");
                 }
         );
     }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -522,6 +522,14 @@ class InvoicingApplicationTests {
                             .andExpect(headers().location().uri("http://localhost/promotions?orders={id}", ORDER_1_ID));
 
                 }
+
+                @Test
+                void getManualPromos_forOrder_shouldReturn_http302_redirect() throws Exception {
+                    mockMvc.perform(get("/orders/{id}/manual-promos", ORDER_1_ID)
+                                    .accept(MediaType.APPLICATION_JSON))
+                            .andExpect(status().isFound())
+                            .andExpect(headers().location().uri("http://localhost/promotions?ordersWithManualPromos={id}", ORDER_1_ID));
+                }
             }
         }
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Order.java
@@ -51,6 +51,11 @@ public class Order {
     @CollectionFilterParam(value = "promos._id", predicate = EntityId.class, documented = false)
     private Set<PromotionCampaign> promos = new HashSet<>();
 
+    @ManyToMany
+    @RestResource(rel = "d:manual-promos", path = "manual-promos")
+    @CollectionFilterParam(value = "manual_promos._id", predicate = EntityId.class, documented = false)
+    private Set<PromotionCampaign> manualPromos = new HashSet<>();
+
     @OneToOne
     @JsonProperty("shipping_address")
     @CollectionFilterParam("shipping_address")

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
@@ -43,6 +43,11 @@ public class PromotionCampaign {
     @CollectionFilterParam(predicate = EntityId.class, documented = false)
     private Set<Order> orders = new HashSet<>();
 
+    @ManyToMany(mappedBy = "manualPromos")
+    @RestResource(exported = false)
+    @CollectionFilterParam(predicate = EntityId.class, documented = false)
+    private Set<Order> ordersWithManualPromos = new HashSet<>();
+
     public PromotionCampaign(String promoCode, String description) {
         this.promoCode = promoCode;
         this.description = description;


### PR DESCRIPTION
Reproduction steps:

1. Have an entity (order) with multiple many-to-many relations (promos & manual-promos) to the same target entity (promotions)
2. Create an order, try to follow the relations to promotions
3. Notice that both relations redirect to the same URL with the same query filter parameters
    In the example here, following the relation to manual-promos redirects to `/promotions?orders=d69ab994-0a7f-4758-9835-5247785fe55d`, which is the inverse relation of `promos`, not `manual-promos`


Also refactored this piece of code to use the spring data
`PersistentEntity` abstraction instead of raw reflection.
