### PR TITLE
Fix validation in the case a newer release dropped the target entity of a required relation

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/BeanValidationRepositoryEventListener.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/BeanValidationRepositoryEventListener.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.data.rest.validation;
 
+import jakarta.validation.groups.Default;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.ObjectProvider;
@@ -38,22 +39,22 @@ public class BeanValidationRepositoryEventListener extends AbstractRepositoryEve
 
     @Override
     protected void onBeforeCreate(Object entity) {
-        validate(entity);
+        validate(entity, Default.class, OnEntityUpdate.class, OnAssociationUpdate.class);
     }
 
     @Override
     protected void onBeforeSave(Object entity) {
-        validate(entity);
+        validate(entity, Default.class, OnEntityUpdate.class);
     }
 
     @Override
     protected void onBeforeLinkSave(Object parent, Object linked) {
-        validate(parent);
+        validate(parent, Default.class, OnAssociationUpdate.class);
     }
 
     @Override
     protected void onBeforeLinkDelete(Object parent, Object linked) {
-        validate(parent);
+        validate(parent, Default.class, OnAssociationUpdate.class);
     }
 
     @Override

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnAssociationUpdate.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnAssociationUpdate.java
@@ -1,0 +1,5 @@
+package com.contentgrid.spring.data.rest.validation;
+
+public interface OnAssociationUpdate {
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnEntityUpdate.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/OnEntityUpdate.java
@@ -1,0 +1,8 @@
+package com.contentgrid.spring.data.rest.validation;
+
+/**
+ * Jakarta Bean Validation group that marks constraints that are only checked before entity updates
+ */
+public interface OnEntityUpdate {
+
+}

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -2,6 +2,7 @@ package com.contentgrid.spring.test.fixture.invoicing.model;
 
 import com.contentgrid.spring.data.rest.validation.AllowedValues;
 import com.contentgrid.spring.data.rest.validation.OnEntityDelete;
+import com.contentgrid.spring.data.rest.validation.OnEntityUpdate;
 import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
@@ -73,7 +74,7 @@ public class Customer {
 
     @Column(unique = true, nullable = false)
     @CollectionFilterParam(predicate = EqualsIgnoreCase.class)
-    @NotNull
+    @NotNull(groups = OnEntityUpdate.class)
     private String vat;
 
     @Embedded

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Invoice.java
@@ -1,6 +1,8 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.OnAssociationUpdate;
 import com.contentgrid.spring.data.rest.validation.OnEntityDelete;
+import com.contentgrid.spring.data.rest.validation.OnEntityUpdate;
 import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
@@ -76,7 +78,7 @@ public class Invoice {
 
     @Column(nullable = false)
     @CollectionFilterParam(predicate = EqualsIgnoreCase.class)
-    @NotNull
+    @NotNull(groups = OnEntityUpdate.class)
     private String number;
 
     private boolean draft;
@@ -125,7 +127,7 @@ public class Invoice {
     @JoinColumn(name = "counterparty", nullable = false)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:counterparty")
     @CollectionFilterParam(predicate = EntityId.class, documented = false)
-    @NotNull
+    @NotNull(groups = OnAssociationUpdate.class)
     private Customer counterparty;
 
     @OneToMany

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/PromotionCampaign.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.OnEntityUpdate;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +34,7 @@ public class PromotionCampaign {
 
     @Column(updatable = false, nullable = false)
     @CollectionFilterParam(value = "promo_code")
-    @NotNull
+    @NotNull(groups = OnEntityUpdate.class)
     private String promoCode;
 
     String description;

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Refund.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Refund.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.OnAssociationUpdate;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
 import com.contentgrid.spring.querydsl.predicate.EntityId;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -30,7 +31,7 @@ public class Refund {
     @CollectionFilterParam
     @CollectionFilterParam(predicate = EntityId.class, documented = false)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:invoice")
-    @NotNull
+    @NotNull(groups = OnAssociationUpdate.class)
     private Invoice invoice;
 
 }


### PR DESCRIPTION
Add support to fix:
- GET requests to existing entities (with required relation removed) result in http 200 instead of http 404
- PUT requests to existing entities (with required relation removed) result in http 200 instead of http 400
- PATCH requests to existing entities (with required relation removed) result in http 200 instead of http 400

Not supported in this PR:
- POST request to create entity (with required relation removed) always fail with http 400

Side effects:
- PATCH request to existing entities where required relation was not removed now result in http 400 database constraint violation instead of http 400 validation failed when using an invalid relation payload (because PATCH doesn't ignore relations unlike PUT)