### PR TITLE
Use strict version instead of enforcedPlatform

### DIFF
--- a/contentgrid-spring-boot-platform/build.gradle
+++ b/contentgrid-spring-boot-platform/build.gradle
@@ -9,15 +9,18 @@ javaPlatform {
 
 
 dependencies {
-    // enforcedPlatform because otherwise spring-content would transitively give us JPA 3.2,
-    // which is not (yet) compatible with Spring Boot.
-    // See https://github.com/paulcwarren/spring-content/pull/2002
-    api enforcedPlatform('org.springframework.boot:spring-boot-dependencies:3.3.1')
+    api platform('org.springframework.boot:spring-boot-dependencies:3.3.1')
     api platform('com.contentgrid.thunx:thunx-bom:0.10.0')
     api platform('com.github.paulcwarren:spring-content-bom:3.0.11')
     api platform('io.cloudevents:cloudevents-bom:3.0.0')
 
     constraints {
+        api('jakarta.persistence:jakarta.persistence-api') {
+            version {
+                strictly '3.1.0'
+            }
+            because 'spring-boot is not compatible with 3.2.0'
+        }
         api project(':contentgrid-spring-boot-starter')
         api project(':contentgrid-spring-boot-starter-annotations')
         api project(':contentgrid-spring-boot-actuators')


### PR DESCRIPTION
Without this exception, gradle won't let us publish the enforcedPlatform dependency statement.
> \* What went wrong:
  Execution failed for task ':contentgrid-spring-boot-platform:generateMetadataFileForPlatformPublication'.
  > Invalid publication 'platform':
      - Variant 'apiElements' contains a dependency on enforced platform 'org.springframework.boot:spring-boot-dependencies'
      - Variant 'runtimeElements' contains a dependency on enforced platform 'org.springframework.boot:spring-boot-dependencies'
    In general publishing dependencies to enforced platforms is a mistake: enforced platforms shouldn't be used for published components because they behave like forced dependencies and leak to consumers. This can result in hard to diagnose dependency resolution errors. If you did this intentionally you can disable this check by adding 'enforced-platform' to the suppressed validations of the :contentgrid-spring-boot-platform:generateMetadataFileForPlatformPublication task. For more on suppressing validations, please refer to https://docs.gradle.org/8.8/userguide/publishing_setup.html#sec:suppressing_validation_errors in the Gradle documentation.