### PR TITLE
Add AllowedValues constraint annotation [ACC-1466]

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
@@ -21,4 +21,11 @@ public class ContentGridHalFormsConfiguration {
     ) {
         return new HalFormsRelationFieldOptionsCustomizer(domainTypeMapping, entityLinks);
     }
+
+    @Bean
+    MediaTypeConfigurationCustomizer<HalFormsConfiguration> contentGridHalFormsAttributeFieldOptionsCustomizer(
+            @FormMapping DomainTypeMapping domainTypeMapping
+    ) {
+        return new HalFormsAttributeFieldOptionsCustomizer(domainTypeMapping);
+    }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
@@ -1,0 +1,43 @@
+package com.contentgrid.spring.data.rest.hal.forms;
+
+import com.contentgrid.spring.data.rest.mapping.Container;
+import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
+import com.contentgrid.spring.data.rest.validation.AllowedValues;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationCustomizer;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsConfiguration;
+import org.springframework.hateoas.mediatype.hal.forms.HalFormsOptions;
+
+@RequiredArgsConstructor
+public class HalFormsAttributeFieldOptionsCustomizer implements MediaTypeConfigurationCustomizer<HalFormsConfiguration> {
+
+    @NonNull
+    private final DomainTypeMapping domainTypeMapping;
+
+    @Override
+    public HalFormsConfiguration customize(HalFormsConfiguration configuration) {
+        for (Class<?> domainType : domainTypeMapping) {
+            var container = domainTypeMapping.forDomainType(domainType);
+            configuration = customizeConfiguration(configuration, domainType, container);
+        }
+        return configuration;
+    }
+
+    private HalFormsConfiguration customizeConfiguration(HalFormsConfiguration configuration, Class<?> domainType,
+            Container container) {
+        var configAtomic = new AtomicReference<>(configuration);
+        container.doWithProperties(property -> {
+            property.findAnnotation(AllowedValues.class)
+                    .map(AllowedValues::options)
+                    .ifPresent(options -> configAtomic.updateAndGet(config -> {
+                        return config.withOptions(domainType, property.getName(), metadata -> {
+                            metadata.getInputType();
+                            return HalFormsOptions.inline(options);
+                        });
+                    }));
+        });
+        return configAtomic.get();
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
@@ -30,10 +30,9 @@ public class HalFormsAttributeFieldOptionsCustomizer implements MediaTypeConfigu
         var configAtomic = new AtomicReference<>(configuration);
         container.doWithProperties(property -> {
             property.findAnnotation(AllowedValues.class)
-                    .map(AllowedValues::options)
+                    .map(AllowedValues::value)
                     .ifPresent(options -> configAtomic.updateAndGet(config -> {
                         return config.withOptions(domainType, property.getName(), metadata -> {
-                            metadata.getInputType();
                             return HalFormsOptions.inline(options);
                         });
                     }));

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValues.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValues.java
@@ -26,7 +26,7 @@ public @interface AllowedValues {
     /**
      * @return the allowed options of the constraint
      */
-    String[] options() default {};
+    String[] value();
 
     /**
      * @return the error message template

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValues.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValues.java
@@ -1,0 +1,46 @@
+package com.contentgrid.spring.data.rest.validation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * The annotated element must have one of the allowed options as value.
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {AllowedValuesValidator.class})
+public @interface AllowedValues {
+
+    /**
+     * @return the allowed options of the constraint
+     */
+    String[] options() default {};
+
+    /**
+     * @return the error message template
+     */
+    String message() default "{com.contentgrid.spring.data.rest.validation.AllowedValues.message}";
+
+    /**
+     * @return the groups the constraint belongs to
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * @return the payload associated to the constraint
+     */
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValuesValidator.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValuesValidator.java
@@ -10,7 +10,7 @@ public class AllowedValuesValidator implements ConstraintValidator<AllowedValues
 
     @Override
     public void initialize(AllowedValues constraintAnnotation) {
-        this.options = Set.of(constraintAnnotation.options());
+        this.options = Set.of(constraintAnnotation.value());
     }
 
     @Override

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValuesValidator.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/validation/AllowedValuesValidator.java
@@ -1,0 +1,24 @@
+package com.contentgrid.spring.data.rest.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class AllowedValuesValidator implements ConstraintValidator<AllowedValues, String> {
+
+    private Set<String> options;
+
+    @Override
+    public void initialize(AllowedValues constraintAnnotation) {
+        this.options = Set.of(constraintAnnotation.options());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            // Null values are checked by other constraints
+            return true;
+        }
+        return options.contains(value);
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverter.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverter.java
@@ -33,6 +33,7 @@ import org.springframework.hateoas.AffordanceModel.InputPayloadMetadata;
 import org.springframework.hateoas.AffordanceModel.Named;
 import org.springframework.hateoas.AffordanceModel.PayloadMetadata;
 import org.springframework.hateoas.AffordanceModel.PropertyMetadata;
+import org.springframework.hateoas.InputType;
 import org.springframework.hateoas.mediatype.InputTypeFactory;
 import org.springframework.hateoas.mediatype.html.HtmlInputType;
 import org.springframework.http.MediaType;
@@ -140,17 +141,22 @@ public class DefaultDomainTypeToHalFormsPayloadMetadataConverter implements
             }
         }
 
-        return new BasicPropertyMetadata(path,
-                property.getTypeInformation().toTypeDescriptor().getResolvableType())
-                .withRequired(property.isRequired())
-                .withReadOnly(false);
+        // Default: use same property metadata as for update form
+        return propertyToMetadataForUpdateForm(property, domainClass, path);
     }
 
     private PropertyMetadata propertyToMetadataForUpdateForm(Property property, Class<?> domainClass, String path) {
-        return new BasicPropertyMetadata(path,
+        var result = new BasicPropertyMetadata(path,
                 property.getTypeInformation().toTypeDescriptor().getResolvableType())
                 .withRequired(property.isRequired())
                 .withReadOnly(false);
+
+        var inputTypeAnnotation = property.findAnnotation(InputType.class);
+
+        if (inputTypeAnnotation.isPresent()) {
+            return result.withInputType(inputTypeAnnotation.get().value());
+        }
+        return result;
     }
 
 

--- a/contentgrid-spring-data-rest/src/main/resources/ValidationMessages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/ValidationMessages.properties
@@ -1,0 +1,1 @@
+com.contentgrid.spring.data.rest.validation.AllowedValues.message= must be one of {value}

--- a/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/validation/ValidationMessages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/validation/ValidationMessages.properties
@@ -1,1 +1,0 @@
-com.contentgrid.spring.data.rest.validation.AllowedValues.message= must be one of {options}

--- a/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/validation/ValidationMessages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/validation/ValidationMessages.properties
@@ -1,0 +1,1 @@
+com.contentgrid.spring.data.rest.validation.AllowedValues.message= must be one of {options}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -1,12 +1,9 @@
 package com.contentgrid.spring.data.rest.affordances;
 
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.repository.CustomerRepository;
 import com.contentgrid.spring.test.security.WithMockJwt;
-import java.util.Set;
-import java.util.UUID;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +34,7 @@ class AffordanceInjectingSelfLinkProviderTest {
 
     @BeforeEach
     void setup() {
-        customer = customerRepository.save(new Customer(UUID.randomUUID(), 0, new AuditMetadata(), "Abc", "ABC", null, null, null, Set.of(), Set.of()));
+        customer = customerRepository.save(new Customer("Abc", "ABC"));
     }
 
     @AfterEach

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -81,7 +81,10 @@ class AffordanceInjectingSelfLinkProviderTest {
                                         },
                                         {
                                             name: "gender",
-                                            type: "text"
+                                            type: "text",
+                                            options: {
+                                                inline: [ "female", "male" ]
+                                            }
                                         },
                                         {
                                             name: "total_spend",
@@ -140,7 +143,10 @@ class AffordanceInjectingSelfLinkProviderTest {
                                                     },
                                                     {
                                                         name: "gender",
-                                                        type: "text"
+                                                        type: "text",
+                                                        options: {
+                                                            inline: [ "female", "male" ]
+                                                        }
                                                     },
                                                     {
                                                         name: "total_spend",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -76,8 +76,12 @@ class AffordanceInjectingSelfLinkProviderTest {
                                             type: "text"
                                         },
                                         {
-                                            name: "birthday"
-                                            #, type: "datetime"
+                                            name: "birthday",
+                                            type: "datetime"
+                                        },
+                                        {
+                                            name: "gender",
+                                            type: "text"
                                         },
                                         {
                                             name: "total_spend",
@@ -131,8 +135,12 @@ class AffordanceInjectingSelfLinkProviderTest {
                                                         type: "text"
                                                     },
                                                     {
-                                                        name: "birthday"
-                                                        #, type: "datetime"
+                                                        name: "birthday",
+                                                        type: "datetime"
+                                                    },
+                                                    {
+                                                        name: "gender",
+                                                        type: "text"
                                                     },
                                                     {
                                                         name: "total_spend",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/affordances/AffordanceInjectingSelfLinkProviderTest.java
@@ -81,7 +81,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                                         },
                                         {
                                             name: "gender",
-                                            type: "text",
+                                            type: "radio",
                                             options: {
                                                 inline: [ "female", "male" ]
                                             }
@@ -143,7 +143,7 @@ class AffordanceInjectingSelfLinkProviderTest {
                                                     },
                                                     {
                                                         name: "gender",
-                                                        type: "text",
+                                                        type: "radio",
                                                         options: {
                                                             inline: [ "female", "male" ]
                                                         }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/auditing/AuditMetadataTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/auditing/AuditMetadataTest.java
@@ -11,7 +11,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
@@ -121,9 +120,7 @@ public class AuditMetadataTest {
         TIMESTAMP = Instant.now().truncatedTo(ChronoUnit.MILLIS);
         Mockito.when(mockedDateTimeProvider.getNow()).thenReturn(Optional.of(TIMESTAMP));
 
-        var xenit = customers.save(
-                new Customer(null, 0, new AuditMetadata(), "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
-                        new HashSet<>()));
+        var xenit = customers.save(new Customer("XeniT", ORG_XENIT_VAT));
 
         XENIT_ID = xenit.getId();
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/auditing/ContentLastModifiedTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/auditing/ContentLastModifiedTest.java
@@ -7,7 +7,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
@@ -85,9 +84,7 @@ public class ContentLastModifiedTest {
 
     @BeforeEach
     void setupTestData() throws Exception {
-        var xenit = customers.save(
-                new Customer(null, 0, new AuditMetadata(), "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
-                        new HashSet<>()));
+        var xenit = customers.save(new Customer("XeniT", ORG_XENIT_VAT));
 
         XENIT_ID = xenit.getId();
         CUSTOMER_CONTENT_URL = "/customers/%s/content".formatted(XENIT_ID);

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/etag/OptimisticLockingTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
@@ -28,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -85,9 +83,7 @@ public class OptimisticLockingTest {
 
     @BeforeEach
     void setupTestData() {
-        var xenit = customers.save(
-                new Customer(null, 0, new AuditMetadata(), "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(),
-                        new HashSet<>()));
+        var xenit = customers.save(new Customer("XeniT", ORG_XENIT_VAT));
 
         XENIT_ID = xenit.getId();
         XENIT_VERSION = xenit.getVersion();

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
@@ -76,7 +76,7 @@ class ContentGridHalFormsConfigurationTest {
                                         properties: [
                                             {
                                                 name: "gender",
-                                                type: "text",
+                                                type: "radio",
                                                 options: {
                                                     inline: [ "female", "male" ]
                                                 }
@@ -166,7 +166,7 @@ class ContentGridHalFormsConfigurationTest {
                                     properties: [
                                         {
                                             name: "gender",
-                                            type: "text",
+                                            type: "radio",
                                             options: {
                                                 inline: [ "female", "male" ]
                                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
@@ -1,6 +1,5 @@
 package com.contentgrid.spring.data.rest.messages;
 
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
@@ -46,7 +45,7 @@ class HalLinkTitlesAndFormPromptsTest {
 
     @BeforeEach
     void setup() {
-        customer = customerRepository.save(new Customer(UUID.randomUUID(), 0, new AuditMetadata(), "Abc", "ABC", null, null, null, Set.of(), Set.of()));
+        customer = customerRepository.save(new Customer("Abc", "ABC"));
         invoice = invoiceRepository.save(new Invoice("12345678", true, true, customer, Set.of()));
         shippingLabel = shippingLabelRepository.save(new ShippingLabel(UUID.randomUUID(), "here", "there", null, null));
     }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
@@ -106,7 +106,7 @@ class HalLinkTitlesAndFormPromptsTest {
                                         },
                                         {
                                             name: "gender",
-                                            type: "text",
+                                            type: "radio",
                                             options: {
                                                 inline: [ "female", "male" ]
                                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
@@ -105,6 +105,10 @@ class HalLinkTitlesAndFormPromptsTest {
                                             type : "datetime"
                                         },
                                         {
+                                            name: "gender",
+                                            type: "text"
+                                        },
+                                        {
                                             prompt: "Spending Total",
                                             name : "total_spend",
                                             type : "number"

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
@@ -106,7 +106,10 @@ class HalLinkTitlesAndFormPromptsTest {
                                         },
                                         {
                                             name: "gender",
-                                            type: "text"
+                                            type: "text",
+                                            options: {
+                                                inline: [ "female", "male" ]
+                                            }
                                         },
                                         {
                                             prompt: "Spending Total",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -255,8 +255,10 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
      * <ul>
      * <li>Create entity without required attribute
      * <li>Create entity without required (-to-one) relation
+     * <li>Create entity with attribute value not in allowed values
      * <li>Update entity to remove/null required attribute
      * <li>Update entity to remove/null required relation
+     * <li>Update entity with attribute value not in allowed values
      * <li>Remove entity relation that is required on this side
      * <li>Remove entity relation that is the target of a required one-to-one relation
      * </ul>
@@ -294,6 +296,23 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                     )
                     .andExpect(validationConstraintViolation()
                             .withError(error -> error.withProperty("counterparty"))
+                    );
+        }
+
+        @Test
+        void createEntityWithAttributeValueNotInAllowedValues() throws Exception {
+            mockMvc.perform(post("/customers")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s",
+                                        "gender": "illegal"
+                                    }
+                                    """.formatted(UUID.randomUUID()))
+                    )
+                    .andExpect(validationConstraintViolation()
+                            .withError(error -> error.withProperty("gender"))
                     );
         }
 
@@ -355,6 +374,37 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                     )
                     .andExpect(validationConstraintViolation()
                             .withError(error -> error.withProperty("counterparty"))
+                    );
+        }
+
+        @Test
+        void updateEntityWithAttributeValueNotInAllowedValues() throws Exception {
+            var customer = createCustomer();
+            mockMvc.perform(put("/customers/{id}", customer.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
+                            .content("""
+                                    {
+                                        "vat": "%s",
+                                        "gender": "illegal"
+                                    }
+                                    """.formatted(customer.getVat()))
+                    )
+                    .andExpect(validationConstraintViolation()
+                            .withError(error -> error.withProperty("gender"))
+                    );
+
+            mockMvc.perform(patch("/customers/{id}", customer.getId())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .accept(MediaTypes.HAL_FORMS_JSON, MediaTypes.HAL_JSON)
+                            .content("""
+                                    {
+                                        "gender": "illegal"
+                                    }
+                                    """)
+                    )
+                    .andExpect(validationConstraintViolation()
+                            .withError(error -> error.withProperty("gender"))
                     );
         }
 

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
@@ -50,6 +50,11 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
                     assertThat(birthday.isReadOnly()).isFalse();
                     assertThat(birthday.isRequired()).isFalse();
                 },
+                gender -> {
+                    assertThat(gender.getName()).isEqualTo("gender");
+                    assertThat(gender.isReadOnly()).isFalse();
+                    assertThat(gender.isRequired()).isFalse();
+                },
                 totalSpend -> {
                     assertThat(totalSpend.getName()).isEqualTo("total_spend");
                     assertThat(totalSpend.isReadOnly()).isFalse();

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
@@ -69,7 +69,10 @@ class HalFormsProfileControllerWithMultipartTest extends AbstractHalFormsProfile
                                         },
                                         {
                                             name: "gender",
-                                            type: "text"
+                                            type: "text",
+                                            options: {
+                                                inline: [ "female", "male" ]
+                                            }
                                         },
                                         {
                                             name: "total_spend",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
@@ -69,7 +69,7 @@ class HalFormsProfileControllerWithMultipartTest extends AbstractHalFormsProfile
                                         },
                                         {
                                             name: "gender",
-                                            type: "text",
+                                            type: "radio",
                                             options: {
                                                 inline: [ "female", "male" ]
                                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithMultipartTest.java
@@ -68,6 +68,10 @@ class HalFormsProfileControllerWithMultipartTest extends AbstractHalFormsProfile
                                             type: "datetime"
                                         },
                                         {
+                                            name: "gender",
+                                            type: "text"
+                                        },
+                                        {
                                             name: "total_spend",
                                             type: "number"
                                         },

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
@@ -65,7 +65,7 @@ class HalFormsProfileControllerWithoutMultipartTest extends AbstractHalFormsProf
                                         },
                                         {
                                             name: "gender",
-                                            type: "text",
+                                            type: "radio",
                                             options: {
                                                 inline: [ "female", "male" ]
                                             }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
@@ -64,6 +64,10 @@ class HalFormsProfileControllerWithoutMultipartTest extends AbstractHalFormsProf
                                             type: "datetime"
                                         },
                                         {
+                                            name: "gender",
+                                            type: "text"
+                                        },
+                                        {
                                             name: "total_spend",
                                             type: "number"
                                         },

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/HalFormsProfileControllerWithoutMultipartTest.java
@@ -65,7 +65,10 @@ class HalFormsProfileControllerWithoutMultipartTest extends AbstractHalFormsProf
                                         },
                                         {
                                             name: "gender",
-                                            type: "text"
+                                            type: "text",
+                                            options: {
+                                                inline: [ "female", "male" ]
+                                            }
                                         },
                                         {
                                             name: "total_spend",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/test/fixture/invoicing/InvoicingApplicationTests.java
@@ -16,7 +16,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
-import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
 import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
 import com.contentgrid.spring.test.fixture.invoicing.model.Order;
@@ -188,8 +187,8 @@ class InvoicingApplicationTests {
         var promoCyber = promos.save(new PromotionCampaign("CYBER-MON", "Cyber Monday"));
         PROMO_CYBER = promoCyber.getPromoCode();
 
-        var xenit = customers.save(new Customer(null, 0, new AuditMetadata(), "XeniT", ORG_XENIT_VAT, null, null, null, new HashSet<>(), new HashSet<>()));
-        var inbev = customers.save(new Customer(null, 0, new AuditMetadata(), "AB InBev", ORG_INBEV_VAT, null, null, null, new HashSet<>(), new HashSet<>()));
+        var xenit = customers.save(new Customer("XeniT", ORG_XENIT_VAT));
+        var inbev = customers.save(new Customer("AB InBev", ORG_INBEV_VAT));
 
         XENIT_ID = xenit.getId();
         INBEV_ID = inbev.getId();

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -88,7 +88,7 @@ public class Customer {
     @CollectionFilterParam
     private Instant birthday;
 
-    @AllowedValues(options = {"female", "male"})
+    @AllowedValues({"female", "male"})
     @InputType(HtmlInputType.RADIO_VALUE)
     private String gender;
 

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -25,7 +25,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Version;
 import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -36,7 +35,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @Getter
 @Setter
 @NoArgsConstructor
-@AllArgsConstructor
 @EntityListeners(AuditingEntityListener.class)
 public class Customer {
 
@@ -103,4 +101,8 @@ public class Customer {
     @Size(max = 0, groups = OnEntityDelete.class)
     private Set<Invoice> invoices = new HashSet<>();
 
+    public Customer(String name, String vat) {
+        this.name = name;
+        this.vat = vat;
+    }
 }

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.test.fixture.invoicing.model;
 
+import com.contentgrid.spring.data.rest.validation.AllowedValues;
 import com.contentgrid.spring.data.rest.validation.OnEntityDelete;
 import com.contentgrid.spring.data.support.auditing.v1.AuditMetadata;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
@@ -84,6 +85,9 @@ public class Customer {
 
     @CollectionFilterParam
     private Instant birthday;
+
+    @AllowedValues(options = {"female", "male"})
+    private String gender;
 
     @JsonProperty("total_spend")
     private Integer totalSpend;

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -31,6 +31,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.content.rest.RestResource;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.hateoas.InputType;
+import org.springframework.hateoas.mediatype.html.HtmlInputType;
 
 @Entity
 @Getter
@@ -87,6 +89,7 @@ public class Customer {
     private Instant birthday;
 
     @AllowedValues(options = {"female", "male"})
+    @InputType(HtmlInputType.RADIO_VALUE)
     private String gender;
 
     @JsonProperty("total_spend")


### PR DESCRIPTION
String Attributes can now be annotated with `@AllowedValues` to limit the possible values that can be assigned to it. The options are also shown in the Hal-Forms templates