### PR TITLE
Ensure that minItems/maxItems is set on AllowedValues-constrainted properties

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
@@ -11,7 +11,8 @@ import org.springframework.hateoas.mediatype.hal.forms.HalFormsConfiguration;
 import org.springframework.hateoas.mediatype.hal.forms.HalFormsOptions;
 
 @RequiredArgsConstructor
-public class HalFormsAttributeFieldOptionsCustomizer implements MediaTypeConfigurationCustomizer<HalFormsConfiguration> {
+public class HalFormsAttributeFieldOptionsCustomizer implements
+        MediaTypeConfigurationCustomizer<HalFormsConfiguration> {
 
     @NonNull
     private final DomainTypeMapping domainTypeMapping;
@@ -33,7 +34,9 @@ public class HalFormsAttributeFieldOptionsCustomizer implements MediaTypeConfigu
                     .map(AllowedValues::value)
                     .ifPresent(options -> configAtomic.updateAndGet(config -> {
                         return config.withOptions(domainType, property.getName(), metadata -> {
-                            return HalFormsOptions.inline(options);
+                            return HalFormsOptions.inline(options)
+                                    .withMinItems(metadata.isRequired() ? 1L : 0L)
+                                    .withMaxItems(property.getTypeInformation().isCollectionLike() ? null : 1L);
                         });
                     }));
         });

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
@@ -78,7 +78,9 @@ class ContentGridHalFormsConfigurationTest {
                                                 name: "gender",
                                                 type: "radio",
                                                 options: {
-                                                    inline: [ "female", "male" ]
+                                                    inline: [ "female", "male" ],
+                                                    minItems: 0,
+                                                    maxItems: 1
                                                 }
                                             },
                                             {},{},{},{},{},{}
@@ -168,7 +170,9 @@ class ContentGridHalFormsConfigurationTest {
                                             name: "gender",
                                             type: "radio",
                                             options: {
-                                                inline: [ "female", "male" ]
+                                                inline: [ "female", "male" ],
+                                                minItems: 0,
+                                                maxItems: 1
                                             }
                                         },
                                         {},{},{},{},{},{}


### PR DESCRIPTION
The HAL-FORMS definition that is generated for a list-of-values constraint is:

```json
{
  "name" : "gender",
  "type" : "text",
  "options" : {
    "inline" : [ "female", "male" ]
  }
}
```

This is valid syntax, but it implies that the field is multi-valued, supporting 0 to infinity items to be selected.

In reality, name is a single-value field, so the correct definition would be
```json
{
  "name" : "gender",
  "type" : "text",
  "options" : {
    "inline" : [ "female", "male" ]
    "maxItems": 1
  }
}
```

This indicates that the field is single-valued, because a maximum of 1 item can be submitted.

`minItems` can optionally also be supplied, set to 0 or 1 to indicate if the field is optional or required. However, this functionality is already covered with a required flag on the property definition, so it's not strictly necessary.