### PR TITLE
Apply `@AllowedValues` constraint on all search filters

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfiguration.java
@@ -3,6 +3,7 @@ package com.contentgrid.spring.data.rest.hal.forms;
 import com.contentgrid.spring.data.rest.mapping.ContentGridDomainTypeMappingConfiguration;
 import com.contentgrid.spring.data.rest.mapping.DomainTypeMapping;
 import com.contentgrid.spring.data.rest.mapping.FormMapping;
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -24,8 +25,9 @@ public class ContentGridHalFormsConfiguration {
 
     @Bean
     MediaTypeConfigurationCustomizer<HalFormsConfiguration> contentGridHalFormsAttributeFieldOptionsCustomizer(
-            @FormMapping DomainTypeMapping domainTypeMapping
+            @FormMapping DomainTypeMapping domainTypeMapping,
+            CollectionFiltersMapping collectionFiltersMapping
     ) {
-        return new HalFormsAttributeFieldOptionsCustomizer(domainTypeMapping);
+        return new HalFormsAttributeFieldOptionsCustomizer(domainTypeMapping, collectionFiltersMapping);
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
@@ -55,6 +55,7 @@ class CollectionFiltersMappingImplTest {
                         "content.mimetype",
                         "content.filename",
                         "birthday",
+                        "gender",
                         "invoices.$$id",
                         "invoices.number",
                         "invoices.paid",

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
@@ -92,6 +92,55 @@ class ContentGridHalFormsConfigurationTest {
     }
 
     @Test
+    void searchFormFieldForConstrainedAttributeOptions() throws Exception {
+        mockMvc.perform(get("/profile/customers").accept(MediaTypes.HAL_FORMS_JSON))
+                .andExpect(content().json("""
+                            {
+                                _templates: {
+                                    "search": {
+                                        properties: [
+                                            {
+                                                "name" : "gender",
+                                                "type" : "text",
+                                                "options" : {
+                                                  "inline" : [ "female", "male" ],
+                                                  "minItems" : 0,
+                                                  "maxItems" : 1
+                                                }
+                                            },
+                                            {},{},{},{},{},{},{},{},{}
+                                        ]
+                                    }
+                                }
+                            }
+                        """));
+    }
+
+    @Test
+    void searchFormFieldForConstrainedAttributeOptionsThroughRelation() throws Exception {
+        mockMvc.perform(get("/profile/orders").accept(MediaTypes.HAL_FORMS_JSON))
+                .andExpect(content().json("""
+                            {
+                                _templates: {
+                                    "search": {
+                                        properties: [
+                                            {
+                                                name: "customer.gender",
+                                                type: "text",
+                                                options: {
+                                                    inline: [ "female", "male" ],
+                                                    maxItems: 1
+                                                }
+                                            },
+                                            {},{},{},{},{},{}
+                                        ]
+                                    }
+                                }
+                            }
+                        """));
+    }
+
+    @Test
     void linkRelationFormFieldForToManyRelationLinksToReferredResource() throws Exception {
         var createdCustomer = mockMvc.perform(
                         post("/customers").contentType(MediaType.APPLICATION_JSON).content("""

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/messages/HalLinkTitlesAndFormPromptsTest.java
@@ -79,6 +79,10 @@ class HalLinkTitlesAndFormPromptsTest {
                                             name: "birthday",
                                             type: "datetime"
                                         },
+                                        {
+                                            name: "gender",
+                                            type: "text"
+                                        },
                                         { name: "content.size", type: "number" }, { name: "content.mimetype", type: "text" }, { name: "content.filename", type: "text" },
                                         { name: "invoices.number", type: "text" }, { name: "invoices.paid", type: "checkbox" }, { name: "invoices.orders.id" }, { name: "invoices.content.length", type: "number" }
                                     ]

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/AbstractHalFormsProfileControllerTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/AbstractHalFormsProfileControllerTest.java
@@ -62,6 +62,10 @@ abstract class AbstractHalFormsProfileControllerTest {
                                             type: "datetime"
                                         },
                                         {
+                                            name: "gender",
+                                            type: "text"
+                                        },
+                                        {
                                             name: "invoices.number",
                                             type: "text"
                                         },
@@ -159,12 +163,14 @@ abstract class AbstractHalFormsProfileControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[4].name",
                         Matchers.is("birthday")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[5].name",
-                        Matchers.is("invoices.number")))
+                        Matchers.is("gender")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[6].name",
-                        Matchers.is("invoices.paid")))
+                        Matchers.is("invoices.number")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[7].name",
-                        Matchers.is("invoices.content.length")))
+                        Matchers.is("invoices.paid")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[8].name",
+                        Matchers.is("invoices.content.length")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$._templates.search.properties[9].name",
                         Matchers.is("invoices.orders.id")));
     }
 }

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverterTest.java
@@ -130,6 +130,7 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
         assertThat(metadata.stream()).map(PropertyMetadata::getName).containsExactlyInAnyOrder(
                 "vat",
                 "birthday",
+                "gender",
                 "content.size",
                 "content.mimetype",
                 "content.filename",
@@ -149,6 +150,7 @@ class DefaultDomainTypeToHalFormsPayloadMetadataConverterTest {
         assertThat(metadata.stream()).map(PropertyMetadata::getName).containsExactlyInAnyOrder(
                 "customer.vat",
                 "customer.birthday",
+                "customer.gender",
                 "customer.content.size",
                 "customer.content.mimetype",
                 "customer.content.filename",

--- a/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
+++ b/contentgrid-spring-data-rest/src/testFixtures/java/com/contentgrid/spring/test/fixture/invoicing/model/Customer.java
@@ -71,7 +71,7 @@ public class Customer {
 
     private String name;
 
-    @Column(unique=true, nullable = false)
+    @Column(unique = true, nullable = false)
     @CollectionFilterParam(predicate = EqualsIgnoreCase.class)
     @NotNull
     private String vat;
@@ -90,6 +90,7 @@ public class Customer {
 
     @AllowedValues({"female", "male"})
     @InputType(HtmlInputType.RADIO_VALUE)
+    @CollectionFilterParam
     private String gender;
 
     @JsonProperty("total_spend")
@@ -100,7 +101,7 @@ public class Customer {
     @CollectionFilterParam(predicate = EntityId.class, documented = false)
     private Set<Order> orders = new HashSet<>();
 
-    @OneToMany(mappedBy="counterparty")
+    @OneToMany(mappedBy = "counterparty")
     @CollectionFilterParam
     @CollectionFilterParam(value = "invoices.$$id", predicate = EntityId.class, documented = false)
     @org.springframework.data.rest.core.annotation.RestResource(rel = "d:invoices")


### PR DESCRIPTION
For search filters that have a different name than the property itself,
also create the options for AllowedValues, so a select can be shown for
them as well
