### PR TITLE
Implement sorting using `@CollectionFilterParam` infrastructure

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/AbstractCollectionFiltersImpl.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/AbstractCollectionFiltersImpl.java
@@ -1,6 +1,8 @@
 package com.contentgrid.spring.data.querydsl.mapping;
 
 import com.contentgrid.spring.querydsl.mapping.CollectionFilters;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.Order;
 import com.querydsl.core.types.Path;
 import java.util.Objects;
 
@@ -13,4 +15,23 @@ abstract class AbstractCollectionFiltersImpl implements CollectionFilters {
         );
     }
 
+    @Override
+    public CollectionFilters forSorting() {
+        return new PredicateCollectionFiltersImpl(
+                this,
+                cf -> !isCrossRelation(cf.getPath()) && cf.createOrderSpecifier(Order.ASC).isPresent()
+        );
+    }
+
+    private static boolean isCrossRelation(Path<?> path) {
+        while (path.getMetadata().getParent() != null) {
+            if (path instanceof EntityPath<?>) {
+                // This goes across a relation; we don't want to order across relations
+                // Note that the root path always is an EntityPath, but it will never be reached due to the condition in the while-loop
+                return true;
+            }
+            path = path.getMetadata().getParent();
+        }
+        return false;
+    }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFilterImpl.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFilterImpl.java
@@ -2,6 +2,8 @@ package com.contentgrid.spring.data.querydsl.mapping;
 
 import com.contentgrid.spring.querydsl.annotation.QuerydslPredicateFactory;
 import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import java.util.Collection;
@@ -32,5 +34,11 @@ class CollectionFilterImpl<T> implements CollectionFilter<T> {
     @Override
     public Optional<Predicate> createPredicate(Collection<T> parameters) {
         return predicateFactory.bind(originalPath, parameters);
+    }
+
+    @Override
+    public Optional<OrderSpecifier<?>> createOrderSpecifier(Order order) {
+        return predicateFactory.sortExpression(originalPath)
+                .map(expr -> new OrderSpecifier<>(order, expr));
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/PredicateCollectionFiltersImpl.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/PredicateCollectionFiltersImpl.java
@@ -2,17 +2,26 @@ package com.contentgrid.spring.data.querydsl.mapping;
 
 import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
 import com.contentgrid.spring.querydsl.mapping.CollectionFilters;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class PredicateCollectionFiltersImpl extends AbstractCollectionFiltersImpl{
+class PredicateCollectionFiltersImpl extends AbstractCollectionFiltersImpl {
+
     private final CollectionFilters collectionFilters;
     private final Predicate<CollectionFilter<?>> predicate;
 
     @Override
     public Stream<CollectionFilter<?>> filters() {
-        return collectionFilters.filters().filter(predicate);
+        return collectionFilters.filters()
+                .filter(predicate);
+    }
+
+    @Override
+    public Optional<CollectionFilter<?>> named(String filterName) {
+        return collectionFilters.named(filterName)
+                .filter(predicate);
     }
 }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/CollectionFilterSortHandlerMethodArgumentResolver.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/CollectionFilterSortHandlerMethodArgumentResolver.java
@@ -1,0 +1,100 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.OrderSpecifier.NullHandling;
+import com.querydsl.core.types.dsl.ComparableExpression;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.rest.webmvc.config.ResourceMetadataHandlerMethodArgumentResolver;
+import org.springframework.data.web.HateoasSortHandlerMethodArgumentResolver;
+import org.springframework.data.web.SortArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class CollectionFilterSortHandlerMethodArgumentResolver extends
+        HateoasSortHandlerMethodArgumentResolver implements SortArgumentResolver {
+
+    private final SortArgumentResolver delegate;
+    private final CollectionFiltersMapping collectionFiltersMapping;
+    private final ResourceMetadataHandlerMethodArgumentResolver resourceMetadataHandlerMethodArgumentResolver;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return delegate.supportsParameter(parameter);
+    }
+
+    @Override
+    @SneakyThrows
+    public Sort resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        var originalSort = delegate.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+        var resourceMetadata = resourceMetadataHandlerMethodArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+
+        var collectionFilters = collectionFiltersMapping.forDomainType(resourceMetadata.getDomainType());
+
+        List<Order> processedOrders = new ArrayList<>();
+        List<OrderSpecifier<?>> orderSpecifiers = new ArrayList<>();
+
+        for (Order order : originalSort) {
+            collectionFilters.named(order.getProperty())
+                    .filter(this::isSortableFilterSpec)
+                    .ifPresent(collectionFilter -> {
+                        orderSpecifiers.add(new OrderSpecifier<>(
+                                convertDirection(order.getDirection()),
+                                (ComparableExpression<?>)collectionFilter.getPath(),
+                                convertNullHandling(order.getNullHandling())
+                        ));
+                        processedOrders.add(order);
+                    });
+
+        }
+
+        return new QSortWithOriginalSort(
+                Sort.by(processedOrders),
+                orderSpecifiers
+        );
+    }
+
+    private boolean isSortableFilterSpec(CollectionFilter<?> collectionFilter) {
+        var path = collectionFilter.getPath();
+        if(!(path instanceof ComparableExpression<?>)) {
+            return false;
+        }
+
+        while(path.getMetadata().getParent() != null) {
+            if(path instanceof EntityPath<?>) {
+                // This goes across a relation; we don't want to order across relations
+                // Note that the root path always is an EntityPath, but it will never be reached due to the condition in the while-loop
+                return false;
+            }
+            path = path.getMetadata().getParent();
+        }
+        return true;
+    }
+
+    private static com.querydsl.core.types.Order convertDirection(Direction direction) {
+        return switch(direction) {
+            case ASC -> com.querydsl.core.types.Order.ASC;
+            case DESC -> com.querydsl.core.types.Order.DESC;
+        };
+    }
+
+    private static NullHandling convertNullHandling(Sort.NullHandling nullHandling) {
+        return switch (nullHandling) {
+            case NATIVE -> NullHandling.Default;
+            case NULLS_FIRST -> NullHandling.NullsFirst;
+            case NULLS_LAST -> NullHandling.NullsLast;
+        };
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/ContentGridCollectionFilterSortConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/ContentGridCollectionFilterSortConfiguration.java
@@ -1,0 +1,92 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.webmvc.RepositoryRestHandlerAdapter;
+import org.springframework.data.rest.webmvc.config.ResourceMetadataHandlerMethodArgumentResolver;
+import org.springframework.data.rest.webmvc.json.MappingAwareDefaultedPageableArgumentResolver;
+import org.springframework.data.rest.webmvc.json.MappingAwarePageableArgumentResolver;
+import org.springframework.data.rest.webmvc.json.MappingAwareSortArgumentResolver;
+import org.springframework.data.util.Lazy;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.SortArgumentResolver;
+import org.springframework.data.web.SortHandlerMethodArgumentResolver;
+import org.springframework.lang.Nullable;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+@Configuration(proxyBeanMethods = false)
+public class ContentGridCollectionFilterSortConfiguration {
+
+    /**
+     * Replaces all "Mapping aware" resolvers with their plain bean variants
+     */
+    @Bean
+    static BeanPostProcessor postProcessRepositoryRestMvcConfigurationRemovingMappingAwareResolvers(ApplicationContext applicationContext) {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if(bean instanceof RepositoryRestHandlerAdapter repositoryRestHandlerAdapter) {
+                    repositoryRestHandlerAdapter.setArgumentResolvers(
+                            replaceArgumentResolvers(
+                                    repositoryRestHandlerAdapter.getArgumentResolvers()
+                            )
+                    );
+                }
+                return bean;
+            }
+
+            private List<HandlerMethodArgumentResolver> replaceArgumentResolvers(
+                    @Nullable List<HandlerMethodArgumentResolver> argumentResolvers
+            ) {
+                if(argumentResolvers == null) {
+                    argumentResolvers = new ArrayList<>();
+                } else {
+                    argumentResolvers = new ArrayList<>(argumentResolvers);
+                }
+
+                // Remove all mapping aware argument resolvers
+                argumentResolvers.removeIf(resolver -> {
+                    return resolver instanceof MappingAwareDefaultedPageableArgumentResolver || resolver instanceof MappingAwarePageableArgumentResolver || resolver instanceof MappingAwareSortArgumentResolver;
+                });
+
+                argumentResolvers.addAll(0, List.of(
+                        new PassthroughDefaultedPageableMethodArgumentResolver(resolveBean(PageableHandlerMethodArgumentResolver.class)),
+                        fromBean(PageableHandlerMethodArgumentResolver.class),
+                        fromBean(SortHandlerMethodArgumentResolver.class)
+                ));
+
+                return argumentResolvers;
+            }
+
+            private <T> Lazy<T> resolveBean(Class<T> beanClass) {
+                return Lazy.of(() -> applicationContext.getBean(beanClass));
+            }
+
+            private HandlerMethodArgumentResolver fromBean(Class<? extends HandlerMethodArgumentResolver> beanClass) {
+                return new LazyResolvingHandlerMethodArgumentResolver<>(resolveBean(beanClass));
+            }
+        };
+    }
+
+    @Bean
+    static BeanPostProcessor postProcessSortHandlerMethodArgumentResolver(
+            @org.springframework.context.annotation.Lazy CollectionFiltersMapping collectionFiltersMapping,
+            @org.springframework.context.annotation.Lazy ResourceMetadataHandlerMethodArgumentResolver resourceMetadataHandlerMethodArgumentResolver
+    ) {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+                if(bean instanceof SortArgumentResolver sortArgumentResolver) {
+                    return new CollectionFilterSortHandlerMethodArgumentResolver(sortArgumentResolver, collectionFiltersMapping, resourceMetadataHandlerMethodArgumentResolver);
+                }
+                return bean;
+            }
+        };
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/LazyResolvingHandlerMethodArgumentResolver.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/LazyResolvingHandlerMethodArgumentResolver.java
@@ -1,0 +1,25 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.util.Lazy;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class LazyResolvingHandlerMethodArgumentResolver<T extends HandlerMethodArgumentResolver> implements HandlerMethodArgumentResolver {
+    private final Lazy<T> delegate;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return delegate.get().supportsParameter(parameter);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        return delegate.get().resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/PassthroughDefaultedPageableMethodArgumentResolver.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/PassthroughDefaultedPageableMethodArgumentResolver.java
@@ -1,0 +1,28 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.rest.webmvc.support.DefaultedPageable;
+import org.springframework.data.util.Lazy;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+public class PassthroughDefaultedPageableMethodArgumentResolver implements HandlerMethodArgumentResolver {
+    private final Lazy<PageableHandlerMethodArgumentResolver> delegate;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return DefaultedPageable.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        var pageable = delegate.get().resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+
+        return new DefaultedPageable(pageable, delegate.get().isFallbackPageable(pageable));
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/QSortWithOriginalSort.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/QSortWithOriginalSort.java
@@ -1,0 +1,23 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import com.querydsl.core.types.OrderSpecifier;
+import java.util.List;
+import lombok.experimental.Delegate;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.querydsl.QSort;
+
+public class QSortWithOriginalSort extends QSort {
+    @Delegate
+    private final Sort originalSort;
+
+    public QSortWithOriginalSort(Sort originalSort, OrderSpecifier<?>... orderSpecifiers) {
+        super(orderSpecifiers);
+        this.originalSort = originalSort;
+    }
+
+    public QSortWithOriginalSort(Sort originalSort, List<OrderSpecifier<?>> orderSpecifiers) {
+        super(orderSpecifiers);
+        this.originalSort = originalSort;
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/QSortWithOriginalSort.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/QSortWithOriginalSort.java
@@ -2,18 +2,24 @@ package com.contentgrid.spring.data.querydsl.sort;
 
 import com.querydsl.core.types.OrderSpecifier;
 import java.util.List;
-import lombok.experimental.Delegate;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.querydsl.QSort;
 
+/**
+ * This class allows using QueryDSL {@link OrderSpecifier} while keeping a reference to the original {@link Sort.Order}
+ * parameters from {@link Sort}
+ * <p>
+ * When the <pre>sort</pre> query parameter is reconstructed based on {@linkplain Sort}, the original
+ * {@linkplain Sort.Order} objects should be used instead of the ones derived from {@linkplain OrderSpecifier} (as
+ * happens in {@linkplain QSort}).
+ */
+@EqualsAndHashCode(callSuper = true)
+@Getter
 public class QSortWithOriginalSort extends QSort {
-    @Delegate
-    private final Sort originalSort;
 
-    public QSortWithOriginalSort(Sort originalSort, OrderSpecifier<?>... orderSpecifiers) {
-        super(orderSpecifiers);
-        this.originalSort = originalSort;
-    }
+    private final Sort originalSort;
 
     public QSortWithOriginalSort(Sort originalSort, List<OrderSpecifier<?>> orderSpecifiers) {
         super(orderSpecifiers);

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/UnsupportedSortPropertyException.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/sort/UnsupportedSortPropertyException.java
@@ -1,0 +1,19 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import lombok.Getter;
+import org.springframework.data.domain.Sort.Order;
+
+/**
+ * Exception for when sorting is requested in an unrecognized property or a property that does not support sorting.
+ * <p>
+ * This exception should only be thrown for invalid values supplied by <i>consumers</i> of the REST API.
+ */
+@Getter
+public class UnsupportedSortPropertyException extends RuntimeException {
+    private final Order order;
+
+    public UnsupportedSortPropertyException(Order order) {
+        super("Sort parameter '%s' is not supported".formatted(order.getProperty()));
+        this.order = order;
+    }
+}

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfiguration.java
@@ -15,6 +15,7 @@ import org.springframework.context.support.MessageSourceAccessor;
 import org.springframework.context.support.MessageSourceSupport;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.core.annotation.Order;
+import org.springframework.data.web.HateoasSortHandlerMethodArgumentResolver;
 import org.springframework.hateoas.UriTemplate;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.hateoas.config.EnableHypermediaSupport.HypermediaType;
@@ -51,13 +52,15 @@ public class ContentGridProblemDetailsConfiguration {
     ContentGridExceptionHandler contentGridExceptionHandler(
             ProblemFactory problemFactory,
             JsonPropertyPathConverter jsonPropertyPathConverter,
-            ResponseEntityFactory responseEntityFactory
+            ResponseEntityFactory responseEntityFactory,
+            HateoasSortHandlerMethodArgumentResolver sortHandlerMethodArgumentResolver
     ) {
         return new ContentGridExceptionHandler(
                 problemFactory,
                 new MessageSourceAccessor(applicationContext),
                 jsonPropertyPathConverter,
-                responseEntityFactory
+                responseEntityFactory,
+                sortHandlerMethodArgumentResolver
         );
     }
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/problem/ProblemType.java
@@ -11,6 +11,7 @@ public enum ProblemType implements ProblemTypeResolvable {
     CONSTRAINT_VIOLATION("integrity", "constraint-violation"),
     INVALID_FILTER_PARAMETER("invalid-filter-parameter"),
     INVALID_FILTER_PARAMETER_FORMAT("invalid-filter-parameter", "format"),
+    INVALID_SORT_PARAMETER("invalid-filter-parameter", "sort"),
 
     INVALID_REQUEST_BODY("invalid-request-body"),
     INVALID_REQUEST_BODY_TYPE("invalid-request-body", "type"),

--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/ContentGridSpringDataRestConfiguration.java
@@ -2,6 +2,7 @@ package org.springframework.data.rest.webmvc;
 
 import com.contentgrid.spring.data.querydsl.mapping.ContentGridCollectionFilterMappingConfiguration;
 import com.contentgrid.spring.data.querydsl.predicate.ContentGridCollectionFilterPredicateConfiguration;
+import com.contentgrid.spring.data.querydsl.sort.ContentGridCollectionFilterSortConfiguration;
 import com.contentgrid.spring.querydsl.resolver.CollectionFilterParamPredicateResolver;
 import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
 import com.contentgrid.thunx.spring.data.querydsl.predicate.injector.rest.webmvc.QuerydslBindingsPredicateResolver;
@@ -18,7 +19,11 @@ import org.springframework.data.rest.core.support.SelfLinkProvider;
 import org.springframework.data.rest.webmvc.support.RepositoryEntityLinks;
 
 @Configuration(proxyBeanMethods = false)
-@Import({ContentGridCollectionFilterMappingConfiguration.class, ContentGridCollectionFilterPredicateConfiguration.class})
+@Import({
+        ContentGridCollectionFilterMappingConfiguration.class,
+        ContentGridCollectionFilterPredicateConfiguration.class,
+        ContentGridCollectionFilterSortConfiguration.class
+})
 public class ContentGridSpringDataRestConfiguration {
 
     @Bean

--- a/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
+++ b/contentgrid-spring-data-rest/src/main/resources/com/contentgrid/spring/data/rest/problem/messages.properties
@@ -19,3 +19,5 @@ com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-filter-parame
 com.contentgrid.spring.data.rest.problem.ProblemType.detail.invalid-filter-parameter=Filter query parameter ''{0}={1}'' is invalid
 com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-filter-parameter.format=Filter query parameter has an invalid format
 com.contentgrid.spring.data.rest.problem.ProblemType.detail.invalid-filter-parameter.format=Filter query parameter ''{0}={1}'' can not be converted to ''{2}''
+com.contentgrid.spring.data.rest.problem.ProblemType.title.invalid-filter-parameter.sort=Sort query parameter is invalid
+com.contentgrid.spring.data.rest.problem.ProblemType.detail.invalid-filter-parameter.sort=Can not sort on property ''{2}''

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactoryTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactoryTest.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.util.TypeInformation;

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersMappingImplTest.java
@@ -70,6 +70,21 @@ class CollectionFiltersMappingImplTest {
     }
 
     @Test
+    void forSorting() {
+        assertThat(collectionFiltersMapping.forDomainType(Customer.class).forSorting().filters())
+                .map(CollectionFilter::getFilterName)
+                .containsExactlyInAnyOrder(
+                        "vat",
+                        "content.size",
+                        "content.mimetype",
+                        "content.filename",
+                        "birthday",
+                        "gender"
+                        // nothing across invoices or orders relations is included
+                );
+    }
+
+    @Test
     void forProperty() {
         assertThat(collectionFiltersMapping.forProperty(Customer.class, "vat"))
                 .hasValueSatisfying(filter -> {

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/sort/CollectionFilterSortHandlerMethodArgumentResolverTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/sort/CollectionFilterSortHandlerMethodArgumentResolverTest.java
@@ -1,0 +1,276 @@
+package com.contentgrid.spring.data.querydsl.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
+import com.contentgrid.spring.data.querydsl.paths.PathNavigator;
+import com.contentgrid.spring.data.querydsl.sort.CollectionFilterSortHandlerMethodArgumentResolverTest.LocalConfiguration;
+import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
+import com.contentgrid.spring.querydsl.mapping.CollectionFiltersMapping;
+import com.contentgrid.spring.querydsl.predicate.EntityId;
+import com.contentgrid.spring.querydsl.predicate.None;
+import com.contentgrid.spring.querydsl.predicate.Text;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Invoice;
+import com.contentgrid.spring.test.fixture.invoicing.model.QCustomer;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.Expressions;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import jakarta.servlet.http.HttpServletRequest;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.querydsl.EntityPathResolver;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.web.SortArgumentResolver;
+import org.springframework.hateoas.server.mvc.UriComponentsContributor;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@SpringBootTest(classes = {InvoicingApplication.class, LocalConfiguration.class})
+@EnableAutoConfiguration(exclude = EventsAutoConfiguration.class)
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+class CollectionFilterSortHandlerMethodArgumentResolverTest {
+
+    @Autowired
+    private SortArgumentResolver sortArgumentResolver;
+
+    @Autowired
+    @Qualifier("sortResolver")
+    private UriComponentsContributor uriComponentsContributor;
+
+    @Autowired
+    private CollectionFiltersMapping collectionFiltersMapping;
+
+    private static final EntityPathResolver entityPathResolver = SimpleEntityPathResolver.INSTANCE;
+
+
+    private static final MethodParameter FAKE_METHOD_PARAM;
+
+    static {
+        try {
+            FAKE_METHOD_PARAM = MethodParameter.forExecutable(
+                    CollectionFilterSortHandlerMethodArgumentResolverTest.class.getDeclaredMethod(
+                            "functionForMethodParameter", Sort.class), 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * This is a stub that is used to create an {@link MethodParameter}: {@link #FAKE_METHOD_PARAM}
+     */
+    @RequestMapping("/{repository}")
+    static void functionForMethodParameter(Sort sort) {
+        // This function is never called, it is just a stub to obtain a MethodParameter
+    }
+
+    private Sort parseRequest(HttpServletRequest request) {
+        return sortArgumentResolver.resolveArgument(
+                FAKE_METHOD_PARAM,
+                null,
+                new ServletWebRequest(request),
+                null
+        );
+    }
+
+    private UriComponents buildComponents(HttpServletRequest request, Sort sort) {
+        var builder = UriComponentsBuilder.fromUriString(request.getRequestURI());
+        uriComponentsContributor.enhance(builder, FAKE_METHOD_PARAM, sort);
+        return builder.build();
+    }
+
+    @Test
+    void simpleStringSort() {
+        var request = new MockHttpServletRequest("GET", "/entity-with-weird-filter-params");
+        request.addParameter("sort", "simple_string");
+        var sort = parseRequest(request);
+
+        var pathNavigator = new PathNavigator(entityPathResolver.createPath(EntityWithWeirdFilterParams.class));
+
+        assertThat(sort)
+                .isInstanceOfSatisfying(QSortWithOriginalSort.class, qSort -> {
+                    assertThat(qSort.getOriginalSort()).containsExactly(Sort.Order.by("simple_string"));
+                    assertThat(qSort.getOrderSpecifiers()).containsExactly(new OrderSpecifier<>(
+                            Order.ASC,
+                            Expressions.stringTemplate("normalize({0s})", pathNavigator.get("simpleString").getPath())
+                    ));
+                });
+
+        assertThat(buildComponents(request, sort).getQueryParams())
+                .containsExactly(Map.entry("sort", List.of("simple_string,asc")));
+    }
+
+    @Test
+    void ignoreCaseStringSort() {
+
+        var request = new MockHttpServletRequest("GET", "/entity-with-weird-filter-params");
+        request.addParameter("sort", "simple_string_ignorecase,desc");
+        var sort = parseRequest(request);
+
+        var pathNavigator = new PathNavigator(entityPathResolver.createPath(EntityWithWeirdFilterParams.class));
+
+        assertThat(sort)
+                .isInstanceOfSatisfying(QSortWithOriginalSort.class, qSort -> {
+                    assertThat(qSort.getOriginalSort()).containsExactly(Sort.Order.desc("simple_string_ignorecase"));
+                    assertThat(qSort.getOrderSpecifiers()).containsExactly(new OrderSpecifier<>(
+                            Order.DESC,
+                            Expressions.stringTemplate("normalize({0s})",
+                                            pathNavigator.get("simpleString").getPath())
+                                    .lower()
+                    ));
+                });
+        assertThat(buildComponents(request, sort).getQueryParams())
+                .containsExactly(Map.entry("sort", List.of("simple_string_ignorecase,desc")));
+    }
+
+    @Test
+    void crossEmbeddedObjectSort() {
+        var request = new MockHttpServletRequest("GET", "/customers");
+        request.addParameter("sort", "content.size");
+        var sort = parseRequest(request);
+
+        assertThat(sort)
+                .isInstanceOfSatisfying(QSortWithOriginalSort.class, qSort -> {
+                    assertThat(qSort.getOriginalSort()).containsExactly(Sort.Order.asc("content.size"));
+                    assertThat(qSort.getOrderSpecifiers()).containsExactly(new OrderSpecifier<>(
+                            Order.ASC,
+                            QCustomer.customer.content.length
+                    ));
+                });
+
+        assertThat(buildComponents(request, sort).getQueryParams())
+                .containsExactly(Map.entry("sort", List.of("content.size,asc")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "myInteger",
+            "myDecimal",
+            "myInstant"
+    })
+    void comparableSort(String param) {
+
+        var request = new MockHttpServletRequest("GET", "/entity-with-weird-filter-params");
+        request.addParameter("sort", param);
+        var sort = parseRequest(request);
+
+        var pathNavigator = new PathNavigator(entityPathResolver.createPath(EntityWithWeirdFilterParams.class));
+
+        assertThat(sort)
+                .isInstanceOfSatisfying(QSortWithOriginalSort.class, qSort -> {
+                    assertThat(qSort.getOriginalSort()).containsExactly(Sort.Order.asc(param));
+                    assertThat(qSort.getOrderSpecifiers()).containsExactly(new OrderSpecifier<>(
+                            Order.ASC,
+                            (Expression<Comparable<?>>) pathNavigator.get(param).getPath()
+                    ));
+                });
+    }
+
+    @Test
+    void unknownSortParameterError() {
+        var request = new MockHttpServletRequest("GET", "/entity-with-weird-filter-params");
+        request.addParameter("sort", "xyz");
+        assertThatThrownBy(() -> parseRequest(request))
+                .hasMessage("Sort parameter 'xyz' is not supported")
+                .isInstanceOfSatisfying(UnsupportedSortPropertyException.class, ex -> {
+                    assertThat(ex.getOrder()).isEqualTo(Sort.Order.asc("xyz"));
+                });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "simple_string_starts_with", // Has no sort mapping
+            "invoice.paid", // Is across a relation
+            "invoice" // Has no sort mapping
+    })
+    void unsupportedSortParameterError(String param) {
+        assertThat(collectionFiltersMapping.forDomainType(EntityWithWeirdFilterParams.class)
+                .named(param))
+                .describedAs(
+                        "A collection filter parameter with name '%s' must exist, so it can be verified that sorting on it is rejected",
+                        param)
+                .isPresent();
+
+        var request = new MockHttpServletRequest("GET", "/entity-with-weird-filter-params");
+        request.addParameter("sort", param);
+        assertThatThrownBy(() -> parseRequest(request))
+                .hasMessage("Sort parameter '%s' is not supported".formatted(param))
+                .isInstanceOfSatisfying(UnsupportedSortPropertyException.class, ex -> {
+                    assertThat(ex.getOrder()).isEqualTo(Sort.Order.asc(param));
+                });
+
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EntityScan(basePackageClasses = {CollectionFilterSortHandlerMethodArgumentResolverTest.class,
+            InvoicingApplication.class})
+    @EnableJpaRepositories(basePackageClasses = {CollectionFilterSortHandlerMethodArgumentResolverTest.class,
+            InvoicingApplication.class}, considerNestedRepositories = true)
+    public static class LocalConfiguration {
+
+    }
+
+    @Entity
+    public static class EntityWithWeirdFilterParams {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        private UUID id;
+
+        @CollectionFilterParam(value = "simple_string", predicate = Text.EqualsNormalized.class)
+        @CollectionFilterParam(value = "simple_string_ignorecase", predicate = Text.EqualsIgnoreCaseNormalized.class)
+        @CollectionFilterParam(value = "simple_string_starts_with", predicate = Text.StartsWithIgnoreCaseNormalized.class)
+        private String simpleString;
+
+        @CollectionFilterParam
+        private Integer myInteger;
+
+        @CollectionFilterParam
+        private BigDecimal myDecimal;
+
+        @CollectionFilterParam
+        private Instant myInstant;
+
+        @OneToOne
+        @CollectionFilterParam(predicate = EntityId.class)
+        @CollectionFilterParam(predicate = None.class)
+        private Invoice invoice;
+    }
+
+    @RepositoryRestResource(path = "entity-with-weird-filter-params")
+    public interface EntityWithWeirdFilterParamsRepository extends
+            JpaRepository<EntityWithWeirdFilterParams, UUID>,
+            QuerydslPredicateExecutor<EntityWithWeirdFilterParams> {
+
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/problem/ContentGridProblemDetailsConfigurationIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
 import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
@@ -560,6 +561,19 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
     class CollectionFilterValueErrors {
 
         @Test
+        void invalidSortParameter() throws Exception {
+            mockMvc.perform(get("/customers?sort=xyz")
+                            .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(problemDetails()
+                            .withStatusCode(HttpStatus.BAD_REQUEST)
+                            .withType(PROBLEM_TYPE_PREFIX + "invalid-filter-parameter/sort")
+                    )
+                    .andExpect(jsonPath("$.property").value("sort"))
+                    .andExpect(jsonPath("$.invalid_value").value("xyz,asc"))
+            ;
+        }
+
+        @Test
         void invalidDateFilterValue() throws Exception {
             mockMvc.perform(get("/customers?birthday=invalid")
                             .accept(MediaType.APPLICATION_JSON)
@@ -567,7 +581,10 @@ class ContentGridProblemDetailsConfigurationIntegrationTest {
                     .andExpect(problemDetails()
                             .withStatusCode(HttpStatus.BAD_REQUEST)
                             .withType(PROBLEM_TYPE_PREFIX + "invalid-filter-parameter/format")
-                    );
+                    )
+                    .andExpect(jsonPath("$.property").value("birthday"))
+                    .andExpect(jsonPath("$.invalid_value").value("invalid"))
+            ;
         }
 
     }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/annotation/CollectionFilterParam.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/annotation/CollectionFilterParam.java
@@ -12,6 +12,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marks an entity field as being available for filtering the collection of entities
+ *
+ * @see com.contentgrid.spring.querydsl.mapping.CollectionFilter for the operational representation
  */
 @Target( { METHOD, FIELD })
 @Retention(RUNTIME)

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/annotation/QuerydslPredicateFactory.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/annotation/QuerydslPredicateFactory.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.querydsl.annotation;
 
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import java.util.Collection;
@@ -40,4 +41,15 @@ public interface QuerydslPredicateFactory<T extends Path<?>,  S> {
      * @return Type to coerce query parameter collection values to
      */
     Class<? extends S> valueType(T path);
+
+    /**
+     * Create expressions to sort by this {@link CollectionFilterParam}
+     *
+     * @param path Property path at the position of the {@link CollectionFilterParam} annotation that references this
+     * factory
+     * @return All {@link Expression}s that will be used for sorting on this field
+     */
+    default Optional<Expression<? extends Comparable<?>>> sortExpression(T path) {
+        return Optional.empty();
+    }
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
@@ -1,5 +1,7 @@
 package com.contentgrid.spring.querydsl.mapping;
 
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import java.util.Collection;
@@ -11,4 +13,15 @@ public interface CollectionFilter<T> {
     Path<T> getPath();
     Class<T> getParameterType();
     Optional<Predicate> createPredicate(Collection<T> parameters);
+
+    /**
+     * Creates a sort order specification from the <code>sort</code> request query parameter
+     * <p>
+     * Not all types of collection filter support sorting. If sorting is not supported, an empty optional will be
+     * returned.
+     *
+     * @param order The direction the property should be sorted in
+     * @return An order specification if one can be created for the specified order and collection filter
+     */
+    Optional<OrderSpecifier<?>> createOrderSpecifier(Order order);
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
@@ -7,11 +7,63 @@ import com.querydsl.core.types.Predicate;
 import java.util.Collection;
 import java.util.Optional;
 
+/**
+ * Operational representation of a {@link com.contentgrid.spring.querydsl.annotation.CollectionFilterParam} annotation
+ * <p>
+ * This operational representation can be resolved from a {@link CollectionFiltersMapping}. A collection filter can be
+ * used to filter a collection of entities. Depending on the concrete implementation, it can also be used for sorting
+ * the collection.
+ *
+ * @param <T> Type of the path referenced by the filter
+ */
 public interface CollectionFilter<T> {
+
+    /**
+     * Obtain the name of the filter
+     * <p>
+     * The name of the filter is used literally as a request query parameter when filtering a collection. It is also
+     * used literally as the property to sort on when using the <pre>sort</pre> parameter for sorting a collection.
+     *
+     * @return The name of the filter
+     */
     String getFilterName();
+
+    /**
+     * Whether this filter is documented or not
+     * <p>
+     * Documented filter parameters are present in schemas and descriptions, undocumented parameters are hidden from
+     * them.
+     * <p>
+     * Filter and sort functionality is active regardless of its documentation state.
+     *
+     * @return Whether this filter is documented or not
+     */
     boolean isDocumented();
+
+    /**
+     * Obtain the QueryDSL Path that is used by this filter
+     * <p>
+     * This method is primarily useful for reverse lookups from Path back to a filter
+     */
     Path<T> getPath();
+
+    /**
+     * Obtain the type of the request query parameter(s) for this filter
+     * <p>
+     * Since query parameters are always strings in their raw format, they may need to be converted to this type before
+     * being used in {@link #createPredicate(Collection)}
+     *
+     * @return The type to convert the request query parameter(s) to
+     */
     Class<T> getParameterType();
+
+    /**
+     * Creates a filter predicate from request query parameters
+     *
+     * @param parameters The query parameters that are converted to the correct type as given by
+     * {@link #getParameterType()}
+     * @return A predicate if one can be created from the parameters
+     */
     Optional<Predicate> createPredicate(Collection<T> parameters);
 
     /**

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
@@ -6,7 +6,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+/**
+ * Holds an ordered set of {@link CollectionFilter}s that can be further filtered down
+ */
 public interface CollectionFilters {
+
+    /**
+     * @return An ordered stream of filters present in this object
+     */
     Stream<CollectionFilter<?>> filters();
 
     /**
@@ -19,12 +26,23 @@ public interface CollectionFilters {
                 .filter(filter -> filter.createOrderSpecifier(Order.ASC).isPresent());
     }
 
+    /**
+     * Restricts filters to those that are applicable to a certain QueryDSL {@link Path}
+     *
+     * @param path The QueryDSL {@link Path} to restrict the filters to
+     * @return A reduced set of {@link CollectionFilter} that can be used for a certain path
+     */
     default CollectionFilters forPath(Path<?> path) {
         return () -> CollectionFilters.this.filters().filter(filter -> Objects.equals(filter.getPath(), path));
     }
 
+    /**
+     * Tries to locate a filter by its name
+     *
+     * @param filterName The filter name to locate the filter for
+     */
     default Optional<CollectionFilter<?>> named(String filterName) {
         return filters().filter(filter -> Objects.equals(filter.getFilterName(), filterName)).findAny();
-    };
+    }
 
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilters.java
@@ -1,5 +1,6 @@
 package com.contentgrid.spring.querydsl.mapping;
 
+import com.querydsl.core.types.Order;
 import com.querydsl.core.types.Path;
 import java.util.Objects;
 import java.util.Optional;
@@ -7,6 +8,16 @@ import java.util.stream.Stream;
 
 public interface CollectionFilters {
     Stream<CollectionFilter<?>> filters();
+
+    /**
+     * Restricts filters to those that can be used for sorting results
+     *
+     * @return A reduced set of {@link CollectionFilter} that can be used for ordering results
+     */
+    default CollectionFilters forSorting() {
+        return () -> CollectionFilters.this.filters()
+                .filter(filter -> filter.createOrderSpecifier(Order.ASC).isPresent());
+    }
 
     default CollectionFilters forPath(Path<?> path) {
         return () -> CollectionFilters.this.filters().filter(filter -> Objects.equals(filter.getPath(), path));

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFiltersMapping.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFiltersMapping.java
@@ -2,10 +2,48 @@ package com.contentgrid.spring.querydsl.mapping;
 
 import java.util.Optional;
 
+/**
+ * Global mapping of Spring Data entities to {@link CollectionFilter}s
+ */
 public interface CollectionFiltersMapping {
+
+    /**
+     * Retrieves all {@link CollectionFilter}s that are defined for an entity
+     *
+     * @param domainType The entity class
+     * @return All collection filters defined for the entity
+     */
     CollectionFilters forDomainType(Class<?> domainType);
 
+    /**
+     * Locates the {@link CollectionFilter} that can be used for filtering on a particular property
+     * <p>
+     * Collection filters for a property can be located e.g. {@code forProperty(Invoice.class, "number")}
+     * <p>
+     * Collection filters for nested properties or that apply across relations can also be located e.g.
+     * {@code forProperty(Invoice.class, "pdf", "mimetype")} or {@code forProperty(Invoice.class", "customer", "name")}
+     * <p>
+     * These examples assume an {@code Invoice} entity class with a "number" property, a "pdf" property that is
+     * {@code @Embedded} and a "customer" property that is a {@code @ManyToOne} relation.
+     *
+     * @param domainType The entity class
+     * @param properties Path of Java property names to follow to arrive at the property
+     * @return The first collection filter for the property, if there is any
+     */
     Optional<CollectionFilter<?>> forProperty(Class<?> domainType, String ...properties);
 
+    /**
+     * Locates the {@link CollectionFilter} that can be used for filtering on the id of a related entity
+     * <p>
+     * Only collection filters that apply across relations can be located using this function. In this case, the
+     * property path needs to point to the relation directly. e.g. {@code forIdProperty(Invoice.class, "customer")}
+     * <p>
+     * This example assumes an {@code Invoice} entity class with a "customer" property that is a {@code @ManyToOne}
+     * relation.
+     *
+     * @param domainType The entity class
+     * @param properties Path of Java property names to follow to arrive at the relation
+     * @return The first collection filter for the {@code @Id} of the entity on the other side of the relation
+     */
     Optional<CollectionFilter<?>> forIdProperty(Class<?> domainType, String... properties);
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/predicate/Default.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/predicate/Default.java
@@ -4,10 +4,13 @@ import com.contentgrid.spring.querydsl.annotation.QuerydslPredicateFactory;
 import com.contentgrid.spring.querydsl.mapping.UnsupportedCollectionFilterPredicateException;
 import com.contentgrid.spring.querydsl.mapping.UnsupportedCollectionFilterPredicatePathTypeException;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BeanPath;
 import com.querydsl.core.types.dsl.CollectionPathBase;
+import com.querydsl.core.types.dsl.ComparableExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.core.types.dsl.SimpleExpression;
 import java.util.Collection;
 import java.util.Optional;
@@ -98,4 +101,13 @@ public class Default implements QuerydslPredicateFactory<Path<?>, Object> {
     public Class<?> valueType(Path<?> path) {
         return path.getType();
     }
+
+    @Override
+    public Optional<Expression<? extends Comparable<?>>> sortExpression(Path<?> path) {
+        if (path instanceof ComparableExpressionBase<?> comparableExpression) {
+            return Optional.of((ComparableExpressionBase<Comparable<?>>) comparableExpression);
+        }
+        return Optional.empty();
+    }
+
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/predicate/Text.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/predicate/Text.java
@@ -2,6 +2,7 @@ package com.contentgrid.spring.querydsl.predicate;
 
 import com.contentgrid.spring.querydsl.mapping.UnsupportedCollectionFilterPredicatePathTypeException;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -68,6 +69,11 @@ public class Text {
             }
             return Optional.of(path.lower().in(values.stream().map(String::toLowerCase).toList()));
         }
+
+        @Override
+        public Optional<Expression<? extends Comparable<?>>> sortExpression(Path<?> path) {
+            return Optional.of(coercePath(path).lower());
+        }
     }
 
     /**
@@ -115,6 +121,11 @@ public class Text {
                     .map(value -> Normalizer.normalize(value, Form.NFKC))
                     .toList()));
         }
+
+        @Override
+        public Optional<Expression<? extends Comparable<?>>> sortExpression(Path<?> path) {
+            return Optional.of(normalize(coercePath(path)));
+        }
     }
 
     /**
@@ -137,6 +148,10 @@ public class Text {
             return Optional.of(normalize(path).lower().in(values.stream()
                     .map(value -> Normalizer.normalize(value, Form.NFKC).toLowerCase())
                     .toList()));
+        }
+        @Override
+        public Optional<Expression<? extends Comparable<?>>> sortExpression(Path<?> path) {
+            return Optional.of(normalize(coercePath(path)).lower());
         }
     }
 

--- a/contentgrid-spring-querydsl/src/testFixtures/java/com/contentgrid/spring/querydsl/test/mapping/TestCollectionFilter.java
+++ b/contentgrid-spring-querydsl/src/testFixtures/java/com/contentgrid/spring/querydsl/test/mapping/TestCollectionFilter.java
@@ -1,6 +1,8 @@
 package com.contentgrid.spring.querydsl.test.mapping;
 
 import com.contentgrid.spring.querydsl.mapping.CollectionFilter;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import java.util.Collection;
@@ -29,6 +31,11 @@ public class TestCollectionFilter<T> implements CollectionFilter<T> {
     @Override
     public Optional<Predicate> createPredicate(Collection<T> parameters) {
         lastParameters = parameters;
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<OrderSpecifier<?>> createOrderSpecifier(Order order) {
         return Optional.empty();
     }
 


### PR DESCRIPTION
- **First iteration to allow sorting on fields using the CollectionFilterParam name**
- **Move logic to create an `OrderSpecifier` to `QuerydslPredicateFactory`**
- **Add javadoc to CollectionFilter mapping APIs**
