### PR TITLE
Minor refactorings around CollectionFilter APIs

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFilterImpl.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFilterImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 import java.util.Optional;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class CollectionFilterImpl<T> implements CollectionFilter<T> {
+
     @Getter
     private final String filterName;
 
@@ -25,6 +27,11 @@ class CollectionFilterImpl<T> implements CollectionFilter<T> {
     private final Path<?> originalPath;
 
     private final QuerydslPredicateFactory<Path<?>, Object> predicateFactory;
+
+    @Override
+    public AnnotatedElement getAnnotatedElement() {
+        return originalPath.getAnnotatedElement();
+    }
 
     @Override
     public Class<T> getParameterType() {

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactory.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactory.java
@@ -73,7 +73,14 @@ class CollectionFiltersFactory {
         var propertyPath = pathNavigator.get(property.getName()).getPath();
         QuerydslPredicateFactory<Path<?>, ?> predicateFactory = instantiator.instantiate(filterParam.predicate());
 
-        return predicateFactory.boundPaths(propertyPath)
+        var boundPaths = predicateFactory.boundPaths(propertyPath).collect(Collectors.toUnmodifiableSet());
+        if (boundPaths.size() > 1) {
+            throw new UnsupportedOperationException(
+                    "Binding to multiple paths is not supported yet (in %s)".formatted(predicateFactory.getClass())
+            );
+        }
+
+        return boundPaths.stream()
                 .map(boundPath -> new CollectionFilterImpl<>(
                         prefix+getName(property, filterParam),
                         boundPath,

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactory.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactory.java
@@ -39,10 +39,10 @@ class CollectionFiltersFactory {
                 CollectionFilter::getFilterName,
                 Function.identity(),
                 (a, b) -> {
-                    throw new IllegalStateException("Duplicate filter name '%s' mapping to paths '%s' and '%s'"
-                            .formatted(a.getFilterName(), a.getPath(), b.getPath()));
+                    throw new IllegalStateException("Duplicate filter name '%s' defined on '%s' and '%s'"
+                            .formatted(a.getFilterName(), a.getAnnotatedElement(), b.getAnnotatedElement()));
                 },
-                // This "factory" supplier ensurers that it remains ordered
+                // This "factory" supplier ensures that it remains ordered
                 LinkedHashMap::new
         ));
 

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/hal/forms/HalFormsAttributeFieldOptionsCustomizer.java
@@ -54,7 +54,7 @@ public class HalFormsAttributeFieldOptionsCustomizer implements
                 // Exclude properties that were already configured
                 .filter(f -> !configuredProperties.contains(f.getFilterName()))
                 .forEach(filter -> {
-                    var allowedValues = filter.getPath().getAnnotatedElement().getAnnotation(AllowedValues.class);
+                    var allowedValues = filter.getAnnotatedElement().getAnnotation(AllowedValues.class);
                     if (allowedValues == null) {
                         return;
                     }

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverter.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/webmvc/DefaultDomainTypeToHalFormsPayloadMetadataConverter.java
@@ -91,7 +91,7 @@ public class DefaultDomainTypeToHalFormsPayloadMetadataConverter implements
                 .filter(CollectionFilter::isDocumented)
                 .<PropertyMetadata>map(filter -> new BasicPropertyMetadata(
                                 filter.getFilterName(),
-                                ResolvableType.forClass(filter.getPath().getType())
+                                ResolvableType.forClass(filter.getParameterType())
                         )
                         .withReadOnly(false)
                 ).toList();

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactoryTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/querydsl/mapping/CollectionFiltersFactoryTest.java
@@ -5,17 +5,26 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.contentgrid.spring.data.querydsl.paths.PathNavigator;
 import com.contentgrid.spring.data.rest.mapping.typeinfo.TypeInformationContainer;
 import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
-import com.querydsl.core.types.EntityPath;
+import com.contentgrid.spring.querydsl.annotation.QuerydslPredicateFactory;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.StringPath;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.util.TypeInformation;
 
 class CollectionFiltersFactoryTest {
-    private static CollectionFiltersFactory createFactoryFor(EntityPath<?> path) {
+
+    private static CollectionFiltersFactory createFactoryFor(EntityPathBase<?> path) {
         return new CollectionFiltersFactory(
                 new DirectPredicateFactoryInstantiator(),
                 "",
@@ -38,6 +47,39 @@ class CollectionFiltersFactoryTest {
 
     }
 
+    @Entity
+    public static class TestEntityWithMultipleBoundPredicate {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.AUTO)
+        private UUID myId;
+
+        @CollectionFilterParam(predicate = MultipleBoundPredicate.class)
+        private String field1;
+
+    }
+
+    private static class MultipleBoundPredicate implements QuerydslPredicateFactory<StringPath, String> {
+
+        @Override
+        public Stream<Path<?>> boundPaths(StringPath path) {
+            return Stream.of(
+                    path,
+                    path.getMetadata().getParent()
+            );
+        }
+
+        @Override
+        public Optional<Predicate> bind(StringPath path, Collection<? extends String> values) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Class<? extends String> valueType(StringPath path) {
+            return String.class;
+        }
+    }
+
     @Test
     void rejectsDuplicateFilterParams() {
         var factory = createFactoryFor(QCollectionFiltersFactoryTest_TestEntityWithDuplicateNames.testEntityWithDuplicateNames);
@@ -45,6 +87,18 @@ class CollectionFiltersFactoryTest {
         assertThatThrownBy(() -> factory.createFilters())
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Duplicate filter name 'field1'");
+    }
+
+    @Test
+    void rejectsMultipleBoundPredicates() {
+        var factory = createFactoryFor(
+                QCollectionFiltersFactoryTest_TestEntityWithMultipleBoundPredicate.testEntityWithMultipleBoundPredicate);
+
+        assertThatThrownBy(() -> factory.createFilters())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Binding to multiple paths is not supported yet (in %s)".formatted(
+                        MultipleBoundPredicate.class
+                ));
     }
 
 }

--- a/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
+++ b/contentgrid-spring-querydsl/src/main/java/com/contentgrid/spring/querydsl/mapping/CollectionFilter.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -46,6 +47,15 @@ public interface CollectionFilter<T> {
      * This method is primarily useful for reverse lookups from Path back to a filter
      */
     Path<T> getPath();
+
+    /**
+     * Obtain the Java property that was annotated with
+     * {@link com.contentgrid.spring.querydsl.annotation.CollectionFilterParam}
+     *
+     * @return The element that is annotated with
+     * {@link com.contentgrid.spring.querydsl.annotation.CollectionFilterParam}
+     */
+    AnnotatedElement getAnnotatedElement();
 
     /**
      * Obtain the type of the request query parameter(s) for this filter

--- a/contentgrid-spring-querydsl/src/test/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverterTest.java
+++ b/contentgrid-spring-querydsl/src/test/java/com/contentgrid/spring/querydsl/converter/CollectionFilterQuerydslPredicateConverterTest.java
@@ -45,7 +45,6 @@ class CollectionFilterQuerydslPredicateConverterTest {
         var filter = TestCollectionFilter.<T>builder()
                 .filterName("test")
                 .path(path)
-                .parameterType((Class<T>)path.getType())
                 .build();
         var converter = new CollectionFilterQuerydslPredicateConverter(
                 createMapping(filter),
@@ -72,7 +71,6 @@ class CollectionFilterQuerydslPredicateConverterTest {
         var filter = TestCollectionFilter.<T>builder()
                 .filterName("test")
                 .path(path)
-                .parameterType((Class<T>)path.getType())
                 .build();
         var converter = new CollectionFilterQuerydslPredicateConverter(
                 createMapping(filter),

--- a/contentgrid-spring-querydsl/src/testFixtures/java/com/contentgrid/spring/querydsl/test/mapping/TestCollectionFilter.java
+++ b/contentgrid-spring-querydsl/src/testFixtures/java/com/contentgrid/spring/querydsl/test/mapping/TestCollectionFilter.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
+import java.lang.reflect.AnnotatedElement;
 import java.util.Collection;
 import java.util.Optional;
 import lombok.Builder;
@@ -23,10 +24,17 @@ public class TestCollectionFilter<T> implements CollectionFilter<T> {
     @NonNull
     private final Path<T> path;
 
-    @NonNull
-    private final Class<T> parameterType;
-
     private Collection<T> lastParameters;
+
+    @Override
+    public AnnotatedElement getAnnotatedElement() {
+        return path.getAnnotatedElement();
+    }
+
+    @Override
+    public Class<T> getParameterType() {
+        return (Class<T>) path.getType();
+    }
 
     @Override
     public Optional<Predicate> createPredicate(Collection<T> parameters) {


### PR DESCRIPTION
- Add direct reference to AnnotatedElement from CollectionFilter
  Previously, this was done via the `Path`; which is not necessarily the annotated item
- Early-error when attempting to bind to multiple paths
  This previously already caused an error, but an unclear error about a duplicate filter name. It is now a dedicated error message referring to this situation.
