### PR TITLE
Ensure that HalConfiguration MediaTypeConfigurationCustomizers are always run

### DIFF
--- a/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
+++ b/contentgrid-spring-boot-autoconfigure/src/main/java/com/contentgrid/spring/boot/autoconfigure/data/web/ContentGridSpringDataRestAutoConfiguration.java
@@ -9,6 +9,8 @@ import com.contentgrid.spring.data.rest.links.ContentGridSpringDataLinksConfigur
 import com.contentgrid.spring.data.rest.problem.ContentGridProblemDetailsConfiguration;
 import com.contentgrid.spring.data.rest.validation.ContentGridSpringDataRestValidationConfiguration;
 import com.contentgrid.spring.data.rest.webmvc.ContentGridSpringDataRestProfileConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -22,6 +24,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.rest.webmvc.ContentGridRestProperties;
 import org.springframework.data.rest.webmvc.ContentGridSpringDataRestConfiguration;
 import org.springframework.data.rest.webmvc.config.RepositoryRestMvcConfiguration;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationCustomizer;
+import org.springframework.hateoas.mediatype.MediaTypeConfigurationFactory;
+import org.springframework.hateoas.mediatype.hal.HalConfiguration;
 
 @AutoConfiguration
 @ConditionalOnBean(RepositoryRestMvcConfiguration.class)
@@ -52,6 +57,21 @@ public class ContentGridSpringDataRestAutoConfiguration {
     @ConfigurationProperties("contentgrid.rest")
     ContentGridRestProperties contentGridRestProperties() {
         return new ContentGridRestProperties();
+    }
+
+    @Bean
+    static BeanPostProcessor contentGridApplyHalConfigurationCustomizers(
+            ObjectProvider<MediaTypeConfigurationCustomizer<HalConfiguration>> customizers
+    ) {
+        return new BeanPostProcessor() {
+            @Override
+            public Object postProcessAfterInitialization(Object bean, String beanName) {
+                if (bean instanceof HalConfiguration halConfiguration) {
+                    return new MediaTypeConfigurationFactory<>(() -> halConfiguration, customizers).getConfiguration();
+                }
+                return bean;
+            }
+        };
     }
 
     @ConditionalOnBean(CurieProviderCustomizer.class)

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/hal/forms/ContentGridHalFormsConfigurationTest.java
@@ -3,6 +3,7 @@ package com.contentgrid.spring.data.rest.hal.forms;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
@@ -231,6 +232,25 @@ class ContentGridHalFormsConfigurationTest {
                         }
                         """)
         );
+    }
+
+    @Test
+    void relationAndContentIsAlwaysArray() throws Exception {
+        var createdCustomer = mockMvc.perform(
+                        post("/customers").contentType(MediaType.APPLICATION_JSON).content("""
+                                {
+                                    "vat": "BE123"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getHeader("Location");
+
+        mockMvc.perform(get(createdCustomer).accept(MediaTypes.HAL_FORMS_JSON))
+                .andExpect(jsonPath("$._links['cg:content']").isArray())
+                .andExpect(jsonPath("$._links['cg:relation']").isArray())
+        ;
     }
 
 }

--- a/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ChangeEventPublicationIntegrationTest.java
+++ b/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ChangeEventPublicationIntegrationTest.java
@@ -57,10 +57,12 @@ public class ChangeEventPublicationIntegrationTest {
                             href: "http://localhost/customers/${#customerId}/orders"
                         }
                     ],
-                    "cg:content": {
-                        name: "content",
-                        href: "http://localhost/customers/${#customerId}/content"
-                    },
+                    "cg:content": [
+                        {
+                            name: "content",
+                            href: "http://localhost/customers/${#customerId}/content"
+                        }
+                    ],
                     "curies": [
                         {
                             name: "d",


### PR DESCRIPTION
`cg:content` & `cg:relation` links are not an array when there is only a single value.

This happens because spring-data-rest does not process `MediaTypeConfigurationCustomizer`, so it does not apply the configuration when pulling the `HalConfiguration` bean directly.
This leads to the configuration settings in `HalConfiguration` inconsistently being applied, depending on if a setting is used in spring-hateoas or spring-data-rest.

Always applying all customizers directly in a `BeanPostProcessor` ensures that the HalConfiguration bean itself has all the customizations directly baked-in,
and does not require all consumers to be aware of `MediaTypeConfigurationCustomizer`.

This _does_ result in `MediaTypeConfigurationCustomizer`s being applied twice where `HalConfiguration` is used in spring-hateoas,
but all usual configurations are idempotent anyways (e.g. adding configuration for a link relation, or setting the ObjectMapper customizer)
