### PR TITLE
Fix event publication test for spring boot 3.4

### DIFF
--- a/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ChangeEventPublicationIntegrationTest.java
+++ b/contentgrid-spring-integration-events/src/test/java/com/contentgrid/spring/integration/events/ChangeEventPublicationIntegrationTest.java
@@ -100,7 +100,6 @@ public class ChangeEventPublicationIntegrationTest {
     @Test
     void entityCreate_emitsEvent() {
         var toCreate = new Customer();
-        toCreate.setId(UUID.randomUUID());
         toCreate.setVat("BE123");
         var customer = customerRepository.save(toCreate);
 


### PR DESCRIPTION
It is not supported to *set* the id of an entity before saving.
This results in an optimistic locking failure.

Because hibernate assumes that an object with an ID was already loaded
from a database, it throws `StaleObjectStateException: Row was updated or deleted by another transaction (or unsaved-value mapping was incorrect)`
