### PR TITLE
Add extension registration properties

### DIFF
--- a/contentgrid-spring-common/src/main/java/com/contentgrid/spring/common/ContentGridApplicationPropertiesConfiguration.java
+++ b/contentgrid-spring-common/src/main/java/com/contentgrid/spring/common/ContentGridApplicationPropertiesConfiguration.java
@@ -11,4 +11,10 @@ public class ContentGridApplicationPropertiesConfiguration {
     ContentGridApplicationProperties contentgridApplicationProperties() {
         return new ContentGridApplicationProperties();
     }
+
+    @Bean
+    @ConfigurationProperties(prefix = "contentgrid.extension")
+    ContentGridExtensionProperties contentGridExtensionProperties() {
+        return new ContentGridExtensionProperties();
+    }
 }

--- a/contentgrid-spring-common/src/main/java/com/contentgrid/spring/common/ContentGridExtensionProperties.java
+++ b/contentgrid-spring-common/src/main/java/com/contentgrid/spring/common/ContentGridExtensionProperties.java
@@ -1,0 +1,25 @@
+package com.contentgrid.spring.common;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Data;
+
+@Data
+public class ContentGridExtensionProperties {
+    private Map<String, ExtensionRegistration> registration = new HashMap<>();
+
+    public Optional<ExtensionRegistration> getRegistration(String extensionName) {
+        return Optional.ofNullable(registration.get(extensionName));
+    }
+
+    @Data
+    public static class ExtensionRegistration {
+        private Map<String, URI> basePath = new HashMap<>();
+
+        public Optional<URI> getBasePath(String prefixName) {
+            return Optional.ofNullable(basePath.get(prefixName));
+        }
+    }
+}


### PR DESCRIPTION
Extension registration is used for supplying extension base URIs that are dependent on the deployment environment.
This way, it can be avoided to hardcode domains for external services, which might change independently of the application itself.
