### PR TITLE
Order supplied `ContentGridLinkCollector`s to be in a neutral position

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringContentRestLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringContentRestLinksConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.content.rest.config.RestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.hateoas.mediatype.MessageResolver;
 
@@ -15,6 +16,7 @@ import org.springframework.hateoas.mediatype.MessageResolver;
 @Import(ContentGridSpringDataLinksConfiguration.class)
 public class ContentGridSpringContentRestLinksConfiguration {
     @Bean
+    @Order(0)
     ContentGridLinkCollector<?> contentGridSpringContentLinkCollector(
             PersistentEntities entities, Stores stores, MappingContext mappingContext,
             RestConfiguration restConfiguration, ContentPropertyToRequestMappingContext requestMappingContext,

--- a/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
+++ b/contentgrid-spring-data-rest/src/main/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfiguration.java
@@ -5,6 +5,7 @@ import com.contentgrid.spring.data.rest.webmvc.ProfileLinksResource;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.repository.support.Repositories;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
@@ -34,12 +35,13 @@ public class ContentGridSpringDataLinksConfiguration {
         return new RepositoryRestConfigurer() {
             @Override
             public LinkCollector customizeLinkCollector(LinkCollector collector) {
-                return new AggregateLinkCollector(collector, collectors);
+                return new AggregateLinkCollector(collector, () -> collectors.orderedStream().iterator());
             }
         };
     }
 
     @Bean
+    @Order(0)
     ContentGridLinkCollector<?> contentGridRelationLinkCollector(PersistentEntities entities, Associations associations,
             SelfLinkProvider selfLinkProvider, MessageResolver resolver) {
         return new SpringDataAssociationLinkCollector(entities, associations, selfLinkProvider, resolver);

--- a/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfigurationTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/com/contentgrid/spring/data/rest/links/ContentGridSpringDataLinksConfigurationTest.java
@@ -1,0 +1,74 @@
+package com.contentgrid.spring.data.rest.links;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.contentgrid.spring.data.rest.links.ContentGridSpringDataLinksConfigurationTest.TestConfig;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.fixture.invoicing.model.Customer;
+import com.contentgrid.spring.test.fixture.invoicing.model.Order;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.webmvc.mapping.LinkCollector;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.mediatype.hal.HalLinkRelation;
+import org.springframework.test.context.ContextConfiguration;
+
+@SpringBootTest
+@ContextConfiguration(classes = {
+        InvoicingApplication.class,
+        TestConfig.class
+})
+class ContentGridSpringDataLinksConfigurationTest {
+    @Autowired
+    LinkCollector linkCollector;
+
+    private static final LinkRelation CUSTOM_REL = HalLinkRelation.uncuried("https://example.com/rels/custom");
+
+    @Configuration(proxyBeanMethods = false)
+    public static class TestConfig {
+        @Bean
+        ContentGridLinkCollector<Customer> customerCustomLinks() {
+            return (customer, links) -> {
+                // Locating the existing content link is part of the test:
+                // this link collector should be ordered after the contentgrid-spring provided ones
+                var contentLink = links.stream()
+                        .filter(link -> link.hasRel(ContentGridLinkRelations.CONTENT) && Objects.equals(link.getName(), "content"))
+                        .findFirst()
+                        .orElseThrow();
+
+                return links.and(contentLink.withRel(CUSTOM_REL));
+            };
+        }
+
+    }
+
+    @Test
+    void classSpecificLinkCollector() {
+        var customer = new Customer();
+        customer.setId(UUID.randomUUID());
+
+        var customerLinks = linkCollector.getLinksFor(customer);
+
+        assertThat(customerLinks.toList())
+                .satisfiesOnlyOnce(link -> {
+                    assertThat(link.getRel()).isEqualTo(CUSTOM_REL);
+                });
+
+        var order = new Order();
+        order.setId(UUID.randomUUID());
+
+        var orderLinks = linkCollector.getLinksFor(order);
+
+        assertThat(orderLinks.toList())
+                .noneSatisfy(link -> {
+                    assertThat(link.getRel()).isEqualTo(CUSTOM_REL);
+                });
+    }
+
+
+}


### PR DESCRIPTION
Using `ObjectProvider#iterator()` returns beans in an unsorted way.

This causes problems when a user-defined `ContentGridLinkCollector` bean tries to use or modify links that are supposed to be added by the `ContentGridLinkCollector`s defined in this project; as the processing order would not be stable.

Using `ObjectProvider#orderedStream()` instead, beans are properly sorted based on their `@Order`.
To allow user-defined `ContentGridLinkCollector`s to order themselves before or after the system-defined ones, place system-defined ones in a neutral position (instead of the `@Order` default lowest-precedence).
Without supplying any `@Order`, beans will be regarded as lowest-precedence, and they are now automatically ordered after the system-defined `ContentGridLinkCollector`s
