### PR TITLE
Prevent clashes between m2m relations with the same name

### DIFF
--- a/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingRepositoryPropertyReferenceController.java
+++ b/contentgrid-spring-data-rest/src/main/java/org/springframework/data/rest/webmvc/DelegatingRepositoryPropertyReferenceController.java
@@ -171,7 +171,11 @@ public class DelegatingRepositoryPropertyReferenceController {
             var inverseSide = repositories.getPersistentEntity(property.getAssociationTargetType());
             for (PersistentProperty<? extends PersistentProperty<?>> inverseProperty : inverseSide.getPersistentProperties(
                     ManyToMany.class)) {
-                if(Objects.equals(property.getName(), inverseProperty.findAnnotation(ManyToMany.class).mappedBy())) {
+                if (
+                        Objects.equals(property.getOwner().getType(), inverseProperty.getActualType()) &&
+                                Objects.equals(property.getName(),
+                                        inverseProperty.findAnnotation(ManyToMany.class).mappedBy())
+                ) {
                     return Optional.of(inverseProperty.getName());
                 }
             }

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/DelegatingRepositoryPropertyReferenceControllerTest.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/DelegatingRepositoryPropertyReferenceControllerTest.java
@@ -1,0 +1,74 @@
+package org.springframework.data.rest.webmvc;
+
+import com.contentgrid.spring.boot.autoconfigure.integration.EventsAutoConfiguration;
+import com.contentgrid.spring.test.fixture.invoicing.InvoicingApplication;
+import com.contentgrid.spring.test.security.WithMockJwt;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest(properties = {
+        "spring.content.storage.type.default=fs",
+        "server.servlet.encoding.enabled=false" // disables mock-mvc enforcing charset in request
+}, classes = {
+        InvoicingApplication.class
+})
+@EnableAutoConfiguration(exclude = EventsAutoConfiguration.class)
+@AutoConfigureMockMvc
+@WithMockJwt
+class DelegatingRepositoryPropertyReferenceControllerTest {
+
+    @TestConfiguration
+    @EntityScan(basePackageClasses = DelegatingRepositoryPropertyReferenceControllerTest.class)
+    class TestConfig {
+
+    }
+
+    @Autowired
+    MockMvc mockMvc;
+
+
+    @SneakyThrows
+    private String createObject(String url) {
+        return mockMvc.perform(MockMvcRequestBuilders.post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn()
+                .getResponse()
+                .getRedirectedUrl();
+    }
+
+    @Test
+    void manyToManyRelation_followed_sameRelationName() throws Exception {
+        var sourceEntity1 = createObject("/source-entity1s");
+        var sourceEntity2 = createObject("/source-entity2s");
+        var targetEntity = createObject("/target-entities");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(sourceEntity1+"/items")
+                .contentType("text/uri-list")
+                .content(targetEntity)
+        ).andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
+
+        mockMvc.perform(MockMvcRequestBuilders.post(sourceEntity2+"/items")
+                .contentType("text/uri-list")
+                .content(targetEntity)
+        ).andExpect(MockMvcResultMatchers.status().is2xxSuccessful());
+
+        mockMvc.perform(MockMvcRequestBuilders.get(sourceEntity1+"/items"))
+                .andExpect(MockMvcResultMatchers.redirectedUrlPattern("http://localhost/target-entities?_internal_sourceEntity1__items=*"));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(sourceEntity2+"/items"))
+                .andExpect(MockMvcResultMatchers.redirectedUrlPattern("http://localhost/target-entities?_internal_sourceEntity2__items=*"));
+    }
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity1.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity1.java
@@ -1,0 +1,40 @@
+package org.springframework.data.rest.webmvc;
+
+import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Version;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class SourceEntity1 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonProperty(access = Access.READ_ONLY)
+    private UUID id;
+
+    @Version
+    private Long version = 0L;
+
+    @ManyToMany
+    @JoinTable(name = "source_entity_1__items", joinColumns = @JoinColumn(name = "source_entity1_id"), inverseJoinColumns = @JoinColumn(name = "target_entity_id"))
+    @CollectionFilterParam("items")
+    @JsonIgnore
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:items", path = "items")
+    private List<TargetEntity> items;
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity1Repository.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity1Repository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.rest.webmvc;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(itemResourceRel = "d:source_entity1", collectionResourceRel = "d:source_entity1s", path = "source-entity1s")
+public interface SourceEntity1Repository extends JpaRepository<SourceEntity1, UUID>, QuerydslPredicateExecutor<SourceEntity1> {
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity2.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity2.java
@@ -1,0 +1,40 @@
+package org.springframework.data.rest.webmvc;
+
+import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Version;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class SourceEntity2 {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonProperty(access = Access.READ_ONLY)
+    private UUID id;
+
+    @Version
+    private Long version = 0L;
+
+    @ManyToMany
+    @JoinTable(name = "source_entity2__items", joinColumns = @JoinColumn(name = "source_entity2_id"), inverseJoinColumns = @JoinColumn(name = "target_entity_id"))
+    @CollectionFilterParam("items")
+    @JsonIgnore
+    @org.springframework.data.rest.core.annotation.RestResource(rel = "d:items", path = "items")
+    private List<TargetEntity> items;
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity2Repository.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/SourceEntity2Repository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.rest.webmvc;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(itemResourceRel = "d:source_entity2", collectionResourceRel = "d:source_entity2s", path = "source-entity2s")
+public interface SourceEntity2Repository extends JpaRepository<SourceEntity2, UUID>, QuerydslPredicateExecutor<SourceEntity2> {
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/TargetEntity.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/TargetEntity.java
@@ -1,0 +1,46 @@
+package org.springframework.data.rest.webmvc;
+
+import com.contentgrid.spring.querydsl.annotation.CollectionFilterParam;
+import com.contentgrid.spring.querydsl.predicate.EntityId;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Version;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.rest.core.annotation.RestResource;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class TargetEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    @JsonProperty(access = Access.READ_ONLY)
+    private UUID id;
+
+    @Version
+    private Long version = 0L;
+
+    @JsonIgnore
+    @RestResource(exported = false)
+    @CollectionFilterParam(predicate = EntityId.class, documented = false)
+    @ManyToMany(mappedBy = "items")
+    private List<SourceEntity1> _internal_sourceEntity1__items;
+
+    @JsonIgnore
+    @RestResource(exported = false)
+    @CollectionFilterParam(predicate = EntityId.class, documented = false)
+    @ManyToMany(mappedBy = "items")
+    private List<SourceEntity2> _internal_sourceEntity2__items;
+
+}

--- a/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/TargetEntityRepository.java
+++ b/contentgrid-spring-data-rest/src/test/java/org/springframework/data/rest/webmvc/TargetEntityRepository.java
@@ -1,0 +1,11 @@
+package org.springframework.data.rest.webmvc;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(itemResourceRel = "d:target_entity", collectionResourceRel = "d:target_entity", path = "target-entities")
+public interface TargetEntityRepository extends JpaRepository<TargetEntity, UUID>, QuerydslPredicateExecutor<TargetEntity> {
+
+}


### PR DESCRIPTION
When multiple many-to-many relations with the same name (from different
source entities) target the same entity; the GET relation endpoint did
not redirect with the correct collection filter.

It should be considered that multiple `@ManyToMany(mappedBy="...")`
annotations with the same `mappedBy` value can legally be present when
they refer to different entities on the other side.
